### PR TITLE
chore(ci): setup automated release workflow with release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: python
+          package-name: docmind-ai-llm
+          bump-minor-pre-major: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python

--- a/docs/developers/release-workflow.md
+++ b/docs/developers/release-workflow.md
@@ -1,0 +1,37 @@
+# Automated Release Workflow
+
+This repository uses [Release Please](https://github.com/googleapis/release-please) to automate the release process, including Semantic Versioning, Changelog generation, and GitHub Releases.
+
+## Configuration
+
+The workflow is defined in [`.github/workflows/release.yml`](../../.github/workflows/release.yml) and is configured for a single Python package.
+
+### Key Settings
+
+- **Trigger**: Runs on every push to the `main` branch.
+- **Release Type**: `python` (Handles `pyproject.toml` version bumping and `CHANGELOG.md` updates).
+- **SemVer Strategy**: `bump-minor-pre-major: true`.
+  - This ensures that breaking changes ( `feat!:` ) increment the **minor** version (e.g., `0.1.0` -> `0.2.0`) rather than the **major** version, protecting the `1.0.0` milestone for the actual stable release.
+
+## How It Works
+
+1. **Commit Messages**: Developers must use [Conventional Commits](https://www.conventionalcommits.org/).
+    - `fix:` -> Patch bump (0.1.0 -> 0.1.1)
+    - `feat:` -> Minor bump (0.1.0 -> 0.2.0)
+    - `feat!:` or `BREAKING CHANGE:` -> Minor bump (0.1.0 -> 0.2.0) (due to pre-major mode).
+    - `chore:` -> No release (usually).
+
+2. **Release PR**:
+    - When commits are merged to `main`, `release-please` analyzes them.
+    - It creates or updates a special "Release PR".
+    - This PR contains the updated `CHANGELOG.md` and the version bump in `pyproject.toml`.
+
+3. **Publishing**:
+    - When a maintainer **merges** the Release PR, `release-please`:
+        - Creates a new GitHub Release.
+        - Tags the commit with the new version (e.g., `v0.2.0`).
+
+## Source of Truth
+
+- **Version**: The `version` field in `pyproject.toml` and the latest GitHub Tag.
+- **Changelog**: `CHANGELOG.md` in the root directory.


### PR DESCRIPTION
This pull request introduces an automated release workflow for the repository, leveraging Release Please to streamline version management and changelog generation. The main updates include the addition of a GitHub Actions workflow for releases and comprehensive developer documentation explaining the new process.

**Release workflow automation:**

* Added `.github/workflows/release.yml` to set up Release Please for automated semantic versioning, changelog updates, and GitHub Releases on every push to the `main` branch, specifically for the Python package `docmind-ai-llm`.

**Developer documentation:**

* Created `docs/developers/release-workflow.md` to document the release automation, including configuration details, commit message requirements, release PR mechanics, and publishing steps. This helps developers understand and adopt the new workflow.