### PR TITLE
fix(release): attribute release PR commits to maintainer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,28 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Require release identity configuration
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          RELEASE_COMMIT_NAME: ${{ vars.RELEASE_COMMIT_NAME }}
+          RELEASE_COMMIT_EMAIL: ${{ vars.RELEASE_COMMIT_EMAIL }}
+        run: |
+          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
+            echo "RELEASE_PLEASE_TOKEN is required so release PR commits are attributed to the maintainer, not github-actions[bot]."
+            exit 1
+          fi
+          if [ -z "$RELEASE_COMMIT_NAME" ]; then
+            echo "RELEASE_COMMIT_NAME repository variable is required for release PR lockfile commits."
+            exit 1
+          fi
+          if [ -z "$RELEASE_COMMIT_EMAIL" ]; then
+            echo "RELEASE_COMMIT_EMAIL repository variable is required for release PR lockfile commits."
+            exit 1
+          fi
       - id: release
         uses: googleapis/release-please-action@v4.4.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
       - name: Validate published release notes
@@ -47,6 +65,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - name: Resolve release PR branch
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         id: release-pr-branch
@@ -86,13 +105,16 @@ jobs:
         run: uv lock
       - name: Commit uv.lock if changed
         if: ${{ steps.release.outputs.prs_created == 'true' && steps.uv-lock-check.outputs.outdated == 'true' }}
+        env:
+          RELEASE_COMMIT_NAME: ${{ vars.RELEASE_COMMIT_NAME }}
+          RELEASE_COMMIT_EMAIL: ${{ vars.RELEASE_COMMIT_EMAIL }}
         run: |
           if git diff --quiet -- uv.lock; then
             echo "uv.lock unchanged."
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "$RELEASE_COMMIT_NAME"
+          git config user.email "$RELEASE_COMMIT_EMAIL"
           git add uv.lock
           git commit -m "chore: update uv.lock for release"
           git push origin "HEAD:${{ steps.release-pr-branch.outputs.branch }}"

--- a/docs/developers/release-workflow.md
+++ b/docs/developers/release-workflow.md
@@ -13,6 +13,14 @@ The workflow is defined in [`.github/workflows/release.yml`](../../.github/workf
 - **Manifest Config**: Advanced Release Please settings live in
   [`release-please-config.json`](../../release-please-config.json) and
   [`.release-please-manifest.json`](../../.release-please-manifest.json).
+- **Release Token**: The workflow requires the repository secret
+  `RELEASE_PLEASE_TOKEN`, a fine-grained personal access token owned by the
+  maintainer whose release PR commits should be credited. The token needs
+  repository contents and pull request write access.
+- **Release Commit Identity**: The workflow requires repository variables
+  `RELEASE_COMMIT_NAME` and `RELEASE_COMMIT_EMAIL` for release PR lockfile
+  commits. Use the maintainer's GitHub noreply email if the email should remain
+  private.
 - **SemVer Strategy**: `bump-minor-pre-major: true`.
   - This ensures that breaking changes ( `feat!:` ) increment the **minor** version (e.g., `0.1.0` -> `0.2.0`) rather than the **major** version, protecting the `1.0.0` milestone for the actual stable release.
 
@@ -29,6 +37,11 @@ The workflow is defined in [`.github/workflows/release.yml`](../../.github/workf
     - It creates or updates a special "Release PR".
     - This PR contains the updated `CHANGELOG.md` and the version bump in `pyproject.toml`.
     - If `uv.lock` is out of date (`uv lock --check`), the workflow regenerates and commits `uv.lock` on the release PR branch.
+    - Release PR commits are created with `RELEASE_PLEASE_TOKEN`. Lockfile
+      follow-up commits use `RELEASE_COMMIT_NAME` and `RELEASE_COMMIT_EMAIL`.
+      Do not use `GITHUB_TOKEN` here; GitHub automatically adds commit authors
+      as squash-merge coauthors, so bot-authored release commits create
+      unwanted bot coauthor trailers.
     - Release PR descriptions must keep the Release Please parseable version
       heading: `## [x.y.z]`, followed by the compare URL and release date.
       Manual note curation can edit bullets and sections inside that block, but


### PR DESCRIPTION
## Summary
- require RELEASE_PLEASE_TOKEN for Release Please so release PR commits are not authored by github-actions[bot]
- use the same token for release PR checkout/push when uv.lock needs refresh
- commit release lockfile updates with Bjorn Melin GitHub noreply identity
- document the required token and why GITHUB_TOKEN should not be used for release PR commits

## Validation
- python YAML parse for .github/workflows/release.yml
- actionlint for .github/workflows/release.yml
- markdownlint for docs/developers/release-workflow.md
- uv run python scripts/check_links.py