### PR TITLE
fix(release): keep release PRs single commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,25 +17,16 @@ jobs:
       - name: Require release identity configuration
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          RELEASE_COMMIT_NAME: ${{ vars.RELEASE_COMMIT_NAME }}
-          RELEASE_COMMIT_EMAIL: ${{ vars.RELEASE_COMMIT_EMAIL }}
         run: |
           if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
             echo "RELEASE_PLEASE_TOKEN is required so release PR commits are attributed to the maintainer, not github-actions[bot]."
-            exit 1
-          fi
-          if [ -z "$RELEASE_COMMIT_NAME" ]; then
-            echo "RELEASE_COMMIT_NAME repository variable is required for release PR lockfile commits."
-            exit 1
-          fi
-          if [ -z "$RELEASE_COMMIT_EMAIL" ]; then
-            echo "RELEASE_COMMIT_EMAIL repository variable is required for release PR lockfile commits."
             exit 1
           fi
       - id: release
         uses: googleapis/release-please-action@v4.4.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
       - name: Validate published release notes
@@ -60,61 +51,3 @@ jobs:
             echo "Release Please could not parse release notes for the tag."
             exit 1
           fi
-      - name: Checkout repository
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-      - name: Resolve release PR branch
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        id: release-pr-branch
-        env:
-          PR_JSON: ${{ steps.release.outputs.pr }}
-        run: |
-          branch="$(echo "$PR_JSON" | jq -r '.headBranchName // .headBranch // .headRefName // empty')"
-          if [ -z "$branch" ]; then
-            echo "Failed to resolve release PR branch." >&2
-            exit 1
-          fi
-          echo "Resolved release PR branch: $branch"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-      - name: Checkout release PR branch
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        run: |
-          git fetch origin "${{ steps.release-pr-branch.outputs.branch }}"
-          git checkout "${{ steps.release-pr-branch.outputs.branch }}"
-      - name: Set up uv
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.12.13"
-          enable-cache: true
-          cache-python: true
-      - name: Check uv.lock status
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        id: uv-lock-check
-        run: |
-          if uv lock --check; then
-            echo "outdated=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "outdated=true" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Update uv.lock
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.uv-lock-check.outputs.outdated == 'true' }}
-        run: uv lock
-      - name: Commit uv.lock if changed
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.uv-lock-check.outputs.outdated == 'true' }}
-        env:
-          RELEASE_COMMIT_NAME: ${{ vars.RELEASE_COMMIT_NAME }}
-          RELEASE_COMMIT_EMAIL: ${{ vars.RELEASE_COMMIT_EMAIL }}
-        run: |
-          if git diff --quiet -- uv.lock; then
-            echo "uv.lock unchanged."
-            exit 0
-          fi
-          git config user.name "$RELEASE_COMMIT_NAME"
-          git config user.email "$RELEASE_COMMIT_EMAIL"
-          git add uv.lock
-          git commit -m "chore: update uv.lock for release"
-          git push origin "HEAD:${{ steps.release-pr-branch.outputs.branch }}"

--- a/docs/developers/release-workflow.md
+++ b/docs/developers/release-workflow.md
@@ -17,10 +17,6 @@ The workflow is defined in [`.github/workflows/release.yml`](../../.github/workf
   `RELEASE_PLEASE_TOKEN`, a fine-grained personal access token owned by the
   maintainer whose release PR commits should be credited. The token needs
   repository contents and pull request write access.
-- **Release Commit Identity**: The workflow requires repository variables
-  `RELEASE_COMMIT_NAME` and `RELEASE_COMMIT_EMAIL` for release PR lockfile
-  commits. Use the maintainer's GitHub noreply email if the email should remain
-  private.
 - **SemVer Strategy**: `bump-minor-pre-major: true`.
   - This ensures that breaking changes ( `feat!:` ) increment the **minor** version (e.g., `0.1.0` -> `0.2.0`) rather than the **major** version, protecting the `1.0.0` milestone for the actual stable release.
 
@@ -35,13 +31,15 @@ The workflow is defined in [`.github/workflows/release.yml`](../../.github/workf
 2. **Release PR**:
     - When commits are merged to `main`, `release-please` analyzes them.
     - It creates or updates a special "Release PR".
-    - This PR contains the updated `CHANGELOG.md` and the version bump in `pyproject.toml`.
-    - If `uv.lock` is out of date (`uv lock --check`), the workflow regenerates and commits `uv.lock` on the release PR branch.
-    - Release PR commits are created with `RELEASE_PLEASE_TOKEN`. Lockfile
-      follow-up commits use `RELEASE_COMMIT_NAME` and `RELEASE_COMMIT_EMAIL`.
-      Do not use `GITHUB_TOKEN` here; GitHub automatically adds commit authors
-      as squash-merge coauthors, so bot-authored release commits create
-      unwanted bot coauthor trailers.
+    - This PR contains the updated `CHANGELOG.md`, the version bump in
+      `pyproject.toml`, and the matching root package version in `uv.lock`.
+    - Release PR commits are created with `RELEASE_PLEASE_TOKEN`. Do not use
+      `GITHUB_TOKEN` here; GitHub automatically adds commit authors as
+      squash-merge coauthors, so bot-authored release commits create unwanted
+      bot coauthor trailers.
+    - Release PRs must stay single-commit. Do not add follow-up lockfile commits
+      from the workflow; `release-please-config.json` updates `uv.lock` through
+      Release Please `extra-files` so the version files remain in one commit.
     - Release PR descriptions must keep the Release Please parseable version
       heading: `## [x.y.z]`, followed by the compare URL and release date.
       Manual note curation can edit bullets and sections inside that block, but

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,13 @@
       "release-type": "python",
       "package-name": "docmind-ai-llm",
       "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name == 'docmind-ai-llm')].version"
+        }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- move the release `uv.lock` version bump into Release Please `extra-files`
- remove the workflow follow-up commit path that can trigger squash coauthor trailers
- document the single-commit Release Please contract

## Validation
- `jq . release-please-config.json >/dev/null && jq . .release-please-manifest.json >/dev/null`
- release workflow YAML and uv.lock TOML parsed with Python
- `uv lock --check`
- `git diff --check`