### PR TITLE
fix(release): skip heavy checks on release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+  auto_review:
+    ignore_title_keywords:
+      - "chore(main): release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build-test:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,6 +102,7 @@ jobs:
           if-no-files-found: ignore
 
   container-static:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   validate-docs:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/developers/release-workflow.md
+++ b/docs/developers/release-workflow.md
@@ -65,6 +65,10 @@ The workflow is defined in [`.github/workflows/release.yml`](../../.github/workf
   `style`, `refactor`, `perf`, `test`, and `deps`.
 - The release workflow fails after publishing if the GitHub Release body is
   blank, which catches Release Please parse failures before they go unnoticed.
+- Generated Release Please PRs skip the heavy CI, docs, and automatic CodeRabbit
+  review lanes. They contain only version and release-note files assembled from
+  already-merged commits, so the useful gate is the Release Please contract
+  itself plus the semantic PR title check.
 - GitHub Releases should use the curated `CHANGELOG.md` release block as their
   source of truth. Do not use GitHub's auto-generated notes for Release Please
   releases; they summarize pull request titles and contributors instead of the

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name == 'docmind-ai-llm')].version"
+          "jsonpath": "$.package[?(@.name.value == 'docmind-ai-llm')].version"
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- skip heavy CI and docs jobs for Release Please PR branches
- add CodeRabbit config to skip automatic reviews for release PR titles
- fix the Release Please TOML JSONPath so `uv.lock` is updated in the single release commit

## Validation
- `jq . release-please-config.json >/dev/null && jq . .release-please-manifest.json >/dev/null`
- YAML files and `uv.lock` TOML parsed with Python
- Release Please `GenericToml` updater changed the root `uv.lock` package version to `0.8.1`
- `uv lock --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized the automated release process by skipping unnecessary CI and documentation checks on Release Please-generated pull requests, improving release efficiency.

* **Documentation**
  * Updated release workflow documentation to clarify how automated releases bypass certain validation gates while maintaining semantic verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->