### PR TITLE
fix(release): use plain semver release tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
-## [0.8.1](https://github.com/BjornMelin/docmind-ai-llm/compare/docmind-ai-llm-v0.8.0...docmind-ai-llm-v0.8.1) (2026-04-30)
+## [0.8.1](https://github.com/BjornMelin/docmind-ai-llm/compare/v0.8.0...v0.8.1) (2026-04-30)
 
 
 ### Bug Fixes
@@ -14,7 +14,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 * **release:** keep release PRs single commit ([66daf65](https://github.com/BjornMelin/docmind-ai-llm/commit/66daf65bae8aeb780218fa619497f3b1e550ced4))
 * **release:** skip heavy checks on release PRs ([7a3b32e](https://github.com/BjornMelin/docmind-ai-llm/commit/7a3b32e175e334169fb5497b4e350a2054e143c6))
 
-## [0.8.0](https://github.com/BjornMelin/docmind-ai-llm/compare/docmind-ai-llm-v0.7.2...docmind-ai-llm-v0.8.0) (2026-04-30)
+## [0.8.0](https://github.com/BjornMelin/docmind-ai-llm/compare/v0.7.2...v0.8.0) (2026-04-30)
 
 
 ### Features

--- a/docs/developers/release-workflow.md
+++ b/docs/developers/release-workflow.md
@@ -13,6 +13,9 @@ The workflow is defined in [`.github/workflows/release.yml`](../../.github/workf
 - **Manifest Config**: Advanced Release Please settings live in
   [`release-please-config.json`](../../release-please-config.json) and
   [`.release-please-manifest.json`](../../.release-please-manifest.json).
+- **Tag and Release Name Format**: Releases use plain SemVer tags and titles,
+  such as `v0.8.2`, not component-prefixed names like
+  `docmind-ai-llm-v0.8.2`.
 - **Release Token**: The workflow requires the repository secret
   `RELEASE_PLEASE_TOKEN`, a fine-grained personal access token owned by the
   maintainer whose release PR commits should be credited. The token needs
@@ -77,4 +80,5 @@ The workflow is defined in [`.github/workflows/release.yml`](../../.github/workf
 ## Source of Truth
 
 - **Version**: The `version` field in `pyproject.toml` and the latest GitHub Tag.
+- **Tag Format**: `v<major>.<minor>.<patch>`.
 - **Changelog**: `CHANGELOG.md` in the root directory.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Summary
- configure Release Please to use plain `v<version>` tags instead of component-prefixed tags
- align the 0.8.0 and 0.8.1 changelog compare links with the plain tag scheme
- document that GitHub Release titles and tags should match exactly, e.g. `v0.8.2`

## Validation
- `jq . release-please-config.json >/dev/null && jq . .release-please-manifest.json >/dev/null`
- YAML parse for release-related workflows and CodeRabbit config
- checked changelog/docs for stale `docmind-ai-llm-v0.8.x` and `docmind-ai-llm: v0.8.x` strings
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog to use standardized version tag format in compare links.
  * Enhanced release workflow documentation with explicit tag format guidelines.
  * Adjusted release configuration for tag generation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->