### PR TITLE
feat(llm): restore llama.cpp server-first GGUF UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,12 +46,12 @@ DOCMIND_OLLAMA_EMBED_DIMENSIONS=
 DOCMIND_OLLAMA_ENABLE_LOGPROBS=false
 # Optional: include top-k alternative tokens per position (0-20) when logprobs enabled.
 DOCMIND_OLLAMA_TOP_LOGPROBS=0
-DOCMIND_LMSTUDIO_BASE_URL=http://localhost:1234/v1
-DOCMIND_VLLM__VLLM_BASE_URL=http://localhost:8000
 # llama.cpp server (OpenAI-compatible GGUF runtime).
 # Use `llama-server --alias <name>` and set DOCMIND_MODEL to that alias when
 # DOCMIND_LLM_BACKEND=llamacpp.
 DOCMIND_LLAMACPP_BASE_URL=http://localhost:8080/v1
+DOCMIND_LMSTUDIO_BASE_URL=http://localhost:1234/v1
+DOCMIND_VLLM__VLLM_BASE_URL=http://localhost:8000
 # DOCMIND_MODEL=local-gguf
 DOCMIND_VLLM__TEMPERATURE=0.1
 DOCMIND_VLLM__MAX_TOKENS=2048

--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,11 @@ DOCMIND_OLLAMA_ENABLE_LOGPROBS=false
 DOCMIND_OLLAMA_TOP_LOGPROBS=0
 DOCMIND_LMSTUDIO_BASE_URL=http://localhost:1234/v1
 DOCMIND_VLLM__VLLM_BASE_URL=http://localhost:8000
+# llama.cpp server (OpenAI-compatible GGUF runtime).
+# Use `llama-server --alias <name>` and set DOCMIND_MODEL to that alias when
+# DOCMIND_LLM_BACKEND=llamacpp.
+DOCMIND_LLAMACPP_BASE_URL=http://localhost:8080/v1
+# DOCMIND_MODEL=local-gguf
 DOCMIND_VLLM__TEMPERATURE=0.1
 DOCMIND_VLLM__MAX_TOKENS=2048
 DOCMIND_VLLM__CONTEXT_WINDOW=131072

--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ Design goals:
 
    # Example - llama.cpp server:
    #   DOCMIND_LLM_BACKEND=llamacpp
-   #   DOCMIND_OPENAI__BASE_URL=http://localhost:8080/v1
+   #   DOCMIND_LLAMACPP_BASE_URL=http://localhost:8080/v1
    #   DOCMIND_OPENAI__API_KEY=not-needed
-   #   DOCMIND_MODEL=your-model-name
+   #   DOCMIND_MODEL=local-gguf
 
    # Offline-first recommended:
    #   HF_HUB_OFFLINE=1
@@ -236,6 +236,23 @@ Design goals:
    #   DOCMIND_OPENAI__API_MODE=responses
    #   DOCMIND_SECURITY__ALLOW_REMOTE_ENDPOINTS=true
    ```
+
+   Start llama.cpp as an OpenAI-compatible GGUF server:
+
+   ```bash
+   # CPU / portable baseline
+   llama-server -m ./models/model.gguf --alias local-gguf \
+     --ctx-size 8192 --host 127.0.0.1 --port 8080
+
+   # CUDA or other GPU backends
+   llama-server -m ./models/model.gguf --alias local-gguf \
+     --ctx-size 8192 -ngl 999 -fa --host 127.0.0.1 --port 8080
+   ```
+
+   Use the `--alias` value as `DOCMIND_MODEL`, keep `/v1` in
+   `DOCMIND_LLAMACPP_BASE_URL`, and bind to loopback unless remote access is
+   explicitly required. For remote access, start `llama-server` with
+   `--api-key` and configure `DOCMIND_OPENAI__API_KEY`.
 
    For a complete overview, see `docs/developers/configuration.md`. The relevant section is `LLM Backend Selection`.
 

--- a/docs/developers/configuration.md
+++ b/docs/developers/configuration.md
@@ -399,11 +399,23 @@ DOCMIND_RETRIEVAL__USE_RERANKING=true
 
 ```env
 DOCMIND_LLM_BACKEND=llamacpp
+DOCMIND_LLAMACPP_BASE_URL=http://localhost:8080/v1
+DOCMIND_MODEL=local-gguf
 DOCMIND_ENABLE_GPU_ACCELERATION=false
 DOCMIND_EMBEDDING__EMBED_DEVICE=cpu
 DOCMIND_SECURITY__ALLOW_REMOTE_ENDPOINTS=false
 DOCMIND_HF_HUB_OFFLINE=1
 ```
+
+Run llama.cpp out of process:
+
+```bash
+llama-server -m ./models/model.gguf --alias local-gguf \
+  --ctx-size 8192 --host 127.0.0.1 --port 8080
+```
+
+Use `--alias` as `DOCMIND_MODEL`. Keep `DOCMIND_LLAMACPP_BASE_URL`
+normalized to `/v1`; DocMind probes `/health` and `/v1/models` from Settings.
 
 ---
 

--- a/docs/specs/spec-001-llm-runtime.md
+++ b/docs/specs/spec-001-llm-runtime.md
@@ -114,7 +114,9 @@ Feature: LLM provider selection
 
   Scenario: Use llama.cpp server
     Given I select 'llamacpp' and set base_url to http://localhost:8080/v1
+    And llama-server reports ready from /health
     Then Settings.llm SHALL be OpenAILike
+    And Settings SHALL expose /v1/models probe status
     And generation SHALL not raise exceptions
 
   Scenario: LM Studio endpoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,19 +43,19 @@ dependencies = [
     # Vector Databases & Clients
     "qdrant-client>=1.15.1,<2.0.0",
     # LlamaIndex (meta + selected integrations)
-    "llama-index>=0.14.12,<0.15.0",
-    "llama-index-vector-stores-qdrant>=0.9.0,<0.10.0",
-    "llama-index-vector-stores-duckdb>=0.5.1,<0.6.0",
-    "llama-index-storage-kvstore-duckdb>=0.2.1,<0.3.0",
-    "llama-index-llms-openai>=0.6.13,<0.7.0",
+    "llama-index>=0.14.21,<0.15.0",
+    "llama-index-vector-stores-qdrant>=0.10.0,<0.11.0",
+    "llama-index-vector-stores-duckdb>=0.6.0,<0.7.0",
+    "llama-index-storage-kvstore-duckdb>=0.3.0,<0.4.0",
+    "llama-index-llms-openai>=0.7.7,<0.8.0",
     "llama-index-llms-ollama>=0.9.1,<1.0.0",
-    "llama-index-llms-openai-like>=0.6.0,<0.7.0",
-    "llama-index-embeddings-huggingface>=0.6.1,<0.7.0",
-    "llama-index-embeddings-clip>=0.5.1,<0.6.0",
-    "llama-index-embeddings-fastembed>=0.5.0,<0.6.0",
-    "llama-index-embeddings-openai>=0.5.1,<0.6.0",
+    "llama-index-llms-openai-like>=0.7.2,<0.8.0",
+    "llama-index-embeddings-huggingface>=0.7.0,<0.8.0",
+    "llama-index-embeddings-clip>=0.6.0,<0.7.0",
+    "llama-index-embeddings-fastembed>=0.6.0,<0.7.0",
+    "llama-index-embeddings-openai>=0.6.0,<0.7.0",
     "fastembed>=0.5.1",                     # Sparse vectors (BM42) CPU support (FR-005)
-    "llama-index-readers-file>=0.5.6,<0.6.0",
+    "llama-index-readers-file>=0.6.0,<0.7.0",
     # Agentic Orchestration
     "langgraph>=1.0.10,<2.0.0",             # Graph-based orchestration
     "langgraph-checkpoint-sqlite>=3.0.3,<4.0.0",  # Durable checkpoints (ADR-058)
@@ -94,7 +94,7 @@ apple = [
     "spacy[apple]; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 llama = [
-    "llama-index-core>=0.14.12,<0.15.0",
+    "llama-index-core>=0.14.21,<0.15.0",
 ]
 graph = [
     "llama-index-graph-stores-kuzu>=0.9.1,<1.0.0",

--- a/src/config/llm_runtime_probe.py
+++ b/src/config/llm_runtime_probe.py
@@ -1,0 +1,125 @@
+"""LLM runtime endpoint probes.
+
+Small HTTP probes used by the Settings UI to validate OpenAI-compatible
+runtime endpoints without constructing an LLM client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProbeResult:
+    """Result from an LLM runtime endpoint probe."""
+
+    ok: bool
+    message: str
+    models_count: int | None = None
+    health_status_code: int | None = None
+    models_status_code: int | None = None
+
+
+def _join_url_path(base: httpx.URL, suffix: str) -> httpx.URL:
+    """Return `base` with `suffix` appended to its current path."""
+    path = base.path.rstrip("/")
+    suffix_path = suffix if suffix.startswith("/") else f"/{suffix}"
+    return base.copy_with(path=f"{path}{suffix_path}")
+
+
+def _llamacpp_health_url(base: httpx.URL) -> httpx.URL:
+    """Return the llama.cpp health URL for a `/v1` API base URL."""
+    path = base.path.rstrip("/")
+    if path.endswith("/v1"):
+        path = path[: -len("/v1")]
+    return base.copy_with(path=f"{path.rstrip('/')}/health")
+
+
+def _model_count(payload: Any) -> int | None:
+    """Extract OpenAI-compatible model count from a response payload."""
+    if not isinstance(payload, dict):
+        return None
+    models = payload.get("data")
+    return len(models) if isinstance(models, list) else None
+
+
+def probe_openai_compatible_runtime(
+    *,
+    base_url: str,
+    backend: str,
+    headers: dict[str, str] | None = None,
+    timeout_s: float = 30.0,
+) -> RuntimeProbeResult:
+    """Probe an OpenAI-compatible runtime endpoint.
+
+    Args:
+        base_url: Normalized OpenAI-compatible base URL, usually ending `/v1`.
+        backend: Runtime backend name.
+        headers: Optional request headers.
+        timeout_s: HTTP timeout in seconds.
+
+    Returns:
+        RuntimeProbeResult with status metadata only.
+    """
+    base = httpx.URL(str(base_url))
+    request_headers = dict(headers or {})
+    timeout = httpx.Timeout(float(timeout_s))
+
+    with httpx.Client(timeout=timeout) as client:
+        if backend == "llamacpp":
+            health_url = _llamacpp_health_url(base)
+            health = client.get(health_url, headers=request_headers)
+            if health.status_code == 503:
+                return RuntimeProbeResult(
+                    ok=False,
+                    message="llama.cpp server is reachable but still loading a model.",
+                    health_status_code=health.status_code,
+                )
+            if health.status_code >= 400:
+                return RuntimeProbeResult(
+                    ok=False,
+                    message=f"llama.cpp health check failed: HTTP {health.status_code}",
+                    health_status_code=health.status_code,
+                )
+            health_status = health.status_code
+        else:
+            health_status = None
+
+        models_url = _join_url_path(base, "/models")
+        models = client.get(models_url, headers=request_headers)
+        if models.status_code >= 400:
+            return RuntimeProbeResult(
+                ok=False,
+                message=f"Model list request failed: HTTP {models.status_code}",
+                health_status_code=health_status,
+                models_status_code=models.status_code,
+            )
+        try:
+            count = _model_count(models.json())
+        except ValueError:
+            return RuntimeProbeResult(
+                ok=True,
+                message="Endpoint reachable; model list returned non-JSON content.",
+                health_status_code=health_status,
+                models_status_code=models.status_code,
+            )
+    if count is None:
+        return RuntimeProbeResult(
+            ok=True,
+            message="Endpoint reachable.",
+            health_status_code=health_status,
+            models_status_code=models.status_code,
+        )
+    return RuntimeProbeResult(
+        ok=True,
+        message=f"Endpoint reachable. Models returned: {count}",
+        models_count=count,
+        health_status_code=health_status,
+        models_status_code=models.status_code,
+    )
+
+
+__all__ = ["RuntimeProbeResult", "probe_openai_compatible_runtime"]

--- a/src/pages/04_settings.py
+++ b/src/pages/04_settings.py
@@ -17,6 +17,7 @@ import streamlit as st
 from pydantic import ValidationError
 
 from src.config.env_persistence import persist_env
+from src.config.llm_runtime_probe import probe_openai_compatible_runtime
 from src.config.settings import DocMindSettings, settings
 from src.config.settings_utils import DEFAULT_OPENAI_BASE_URL, ensure_v1
 from src.retrieval import adapter_registry
@@ -238,6 +239,7 @@ def main() -> None:
         openai_ui_errors = []
 
     ollama_url, vllm_url, lmstudio_url, llamacpp_url = _render_provider_urls(provider)
+    _render_llamacpp_server_guide(provider)
     (
         ollama_api_key,
         ollama_enable_web_search,
@@ -836,6 +838,10 @@ def _validate_llamacpp_inputs(
     normalized_llamacpp_url = (
         ensure_v1(clean_llamacpp_url) if clean_llamacpp_url else None
     )
+    if normalized_llamacpp_url in _LLAMACPP_DISALLOWED_SHARED_URLS:
+        ui_errors.append("Provide a llama.cpp OpenAI-compatible server URL.")
+        return ui_errors
+
     has_llamacpp_url = bool(normalized_llamacpp_url)
     has_custom_shared_url = (
         bool(normalized_openai_base_url)
@@ -846,6 +852,45 @@ def _validate_llamacpp_inputs(
 
     ui_errors.append("Provide a llama.cpp OpenAI-compatible server URL.")
     return ui_errors
+
+
+def _render_llamacpp_server_guide(provider: str) -> None:
+    """Render llama.cpp server launch guidance for GGUF users."""
+    if provider != "llamacpp":
+        return
+
+    st.subheader("llama.cpp server")
+    st.caption(
+        "DocMind uses llama.cpp through `llama-server`'s OpenAI-compatible "
+        "HTTP API. Keep the server bound to loopback unless you explicitly "
+        "need remote access."
+    )
+    with st.expander("Launch examples", expanded=True):
+        st.code(
+            "\n".join(
+                (
+                    "# CPU / portable baseline",
+                    "llama-server -m ./models/model.gguf --alias local-gguf "
+                    "--ctx-size 8192 --host 127.0.0.1 --port 8080",
+                    "",
+                    "# CUDA or other GPU backends",
+                    "llama-server -m ./models/model.gguf --alias local-gguf "
+                    "--ctx-size 8192 -ngl 999 -fa --host 127.0.0.1 --port 8080",
+                    "",
+                    "# Add auth when exposing beyond local loopback",
+                    "llama-server -m ./models/model.gguf --alias local-gguf "
+                    "--api-key $DOCMIND_OPENAI__API_KEY --host 0.0.0.0 --port 8080",
+                )
+            ),
+            language="bash",
+        )
+        st.markdown(
+            "- Set **Model ID** to the `--alias` value, for example `local-gguf`.\n"
+            "- Set **llama.cpp server URL** to `http://localhost:8080/v1`.\n"
+            "- Match **Context window** to `--ctx-size`.\n"
+            "- Use trusted GGUF files only; DocMind does not load local GGUF "
+            "paths in-process."
+        )
 
 
 class SettingsFormValues(TypedDict):
@@ -979,7 +1024,10 @@ def _render_endpoint_test(validated: DocMindSettings | None) -> None:
         return
 
     st.subheader("Connectivity Test")
-    st.caption("Sends a lightweight `GET /models` request to the configured endpoint.")
+    st.caption(
+        "Sends lightweight readiness requests to the configured endpoint. "
+        "For llama.cpp this checks `/health` before `/v1/models`."
+    )
     cooldown_key = "docmind_endpoint_test_last_ts"
     cooldown_s = 3.0
     now = time.monotonic()
@@ -997,28 +1045,22 @@ def _render_endpoint_test(validated: DocMindSettings | None) -> None:
     st.session_state[cooldown_key] = now
 
     try:
-        import httpx
-
-        base = httpx.URL(str(base_url))
-        url = str(base.copy_with(path=base.path.rstrip("/") + "/models"))
         headers = _build_endpoint_test_headers(validated)
-
         timeout_s = min(30.0, float(validated.llm_request_timeout_seconds))
-        with httpx.Client(timeout=timeout_s) as client:
-            resp = client.get(url, headers=headers)
-        if resp.status_code >= 400:
-            st.error(f"Endpoint test failed: HTTP {resp.status_code}")
-            return
-        try:
-            payload = resp.json()
-        except ValueError:
-            st.success("Endpoint reachable (non-JSON response).")
-            return
-        models = payload.get("data")
-        if isinstance(models, list):
-            st.success(f"Endpoint reachable. Models returned: {len(models)}")
+        result = probe_openai_compatible_runtime(
+            base_url=str(base_url),
+            backend=backend_type,
+            headers=headers,
+            timeout_s=timeout_s,
+        )
+        if result.ok:
+            st.success(result.message)
         else:
-            st.success("Endpoint reachable.")
+            st.error(result.message)
+        if result.health_status_code is not None:
+            st.caption(f"Health status: HTTP {result.health_status_code}")
+        if result.models_status_code is not None:
+            st.caption(f"Models status: HTTP {result.models_status_code}")
     except Exception as exc:  # pragma: no cover - UI feedback
         from src.utils.log_safety import build_pii_log_entry
 

--- a/src/pages/04_settings.py
+++ b/src/pages/04_settings.py
@@ -35,6 +35,9 @@ _LLAMACPP_DISALLOWED_SHARED_URLS = frozenset(
         },
     )
 )
+_LLAMACPP_DISALLOWED_EXPLICIT_URLS = frozenset(
+    {"https://api.openai.com", "https://api.openai.com/v1"}
+)
 
 _OPENAI_BASE_URL_KEY = "docmind_openai_base_url"
 _OPENAI_API_KEY_KEY = "docmind_openai_api_key"
@@ -838,7 +841,7 @@ def _validate_llamacpp_inputs(
     normalized_llamacpp_url = (
         ensure_v1(clean_llamacpp_url) if clean_llamacpp_url else None
     )
-    if normalized_llamacpp_url in _LLAMACPP_DISALLOWED_SHARED_URLS:
+    if normalized_llamacpp_url in _LLAMACPP_DISALLOWED_EXPLICIT_URLS:
         ui_errors.append("Provide a llama.cpp OpenAI-compatible server URL.")
         return ui_errors
 

--- a/tests/unit/config/test_llm_runtime_probe.py
+++ b/tests/unit/config/test_llm_runtime_probe.py
@@ -1,0 +1,144 @@
+"""Tests for LLM runtime endpoint probes."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.config import llm_runtime_probe
+
+
+class _Response:
+    """Small httpx.Response stand-in for probe tests."""
+
+    def __init__(self, status_code: int, payload: object | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> object:
+        """Return configured JSON payload."""
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+@pytest.mark.unit
+def test_llamacpp_probe_checks_health_before_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """llama.cpp probe checks `/health` before `/v1/models`."""
+    requests: list[tuple[str, dict[str, str] | None]] = []
+
+    class _Client:
+        def __init__(self, *, timeout: object) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: object,
+            *,
+            headers: dict[str, str] | None = None,
+        ) -> _Response:
+            raw = str(url)
+            requests.append((raw, headers))
+            if raw.endswith("/health"):
+                return _Response(200, {"status": "ok"})
+            return _Response(200, {"data": [{"id": "local-gguf"}]})
+
+    monkeypatch.setattr(llm_runtime_probe.httpx, "Client", _Client)
+
+    result = llm_runtime_probe.probe_openai_compatible_runtime(
+        base_url="http://localhost:8080/v1",
+        backend="llamacpp",
+        headers={"Authorization": "Bearer local"},
+        timeout_s=5.0,
+    )
+
+    assert result.ok is True
+    assert result.models_count == 1
+    assert requests == [
+        ("http://localhost:8080/health", {"Authorization": "Bearer local"}),
+        ("http://localhost:8080/v1/models", {"Authorization": "Bearer local"}),
+    ]
+
+
+@pytest.mark.unit
+def test_llamacpp_probe_reports_loading_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """llama.cpp loading status should not fall through to `/models`."""
+    calls = 0
+
+    class _Client:
+        def __init__(self, *, timeout: object) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: object,
+            *,
+            headers: dict[str, str] | None = None,
+        ) -> _Response:
+            nonlocal calls
+            calls += 1
+            return _Response(503, {"error": {"message": "Loading model"}})
+
+    monkeypatch.setattr(llm_runtime_probe.httpx, "Client", _Client)
+
+    result = llm_runtime_probe.probe_openai_compatible_runtime(
+        base_url="http://localhost:8080/v1",
+        backend="llamacpp",
+    )
+
+    assert result.ok is False
+    assert "loading" in result.message
+    assert calls == 1
+
+
+@pytest.mark.unit
+def test_openai_compatible_probe_uses_models_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generic OpenAI-compatible probe should only call `/models`."""
+    requests: list[str] = []
+
+    class _Client:
+        def __init__(self, *, timeout: object) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: object,
+            *,
+            headers: dict[str, str] | None = None,
+        ) -> _Response:
+            requests.append(str(url))
+            return _Response(200, {"data": []})
+
+    monkeypatch.setattr(llm_runtime_probe.httpx, "Client", _Client)
+
+    result = llm_runtime_probe.probe_openai_compatible_runtime(
+        base_url="http://localhost:1234/v1",
+        backend="lmstudio",
+    )
+
+    assert result.ok is True
+    assert result.models_count == 0
+    assert requests == ["http://localhost:1234/v1/models"]

--- a/tests/unit/pages/test_settings_page_validation.py
+++ b/tests/unit/pages/test_settings_page_validation.py
@@ -104,7 +104,7 @@ def test_validate_llamacpp_inputs_rejects_default_openai_base_url(
 
 
 @pytest.mark.unit
-def test_validate_llamacpp_inputs_accepts_explicit_default_llamacpp_url(
+def test_validate_llamacpp_inputs_rejects_explicit_default_llamacpp_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     page = _load_settings_page_module(monkeypatch)
@@ -114,7 +114,7 @@ def test_validate_llamacpp_inputs_accepts_explicit_default_llamacpp_url(
         "https://api.openai.com/v1",
     )
 
-    assert errors == []
+    assert errors == ["Provide a llama.cpp OpenAI-compatible server URL."]
 
 
 @pytest.mark.unit

--- a/tests/unit/pages/test_settings_page_validation.py
+++ b/tests/unit/pages/test_settings_page_validation.py
@@ -89,6 +89,20 @@ def test_validate_llamacpp_inputs_accepts_openai_base_url(
 
 
 @pytest.mark.unit
+def test_validate_llamacpp_inputs_accepts_explicit_localhost_1234(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = _load_settings_page_module(monkeypatch)
+
+    errors = page._validate_llamacpp_inputs(
+        "llamacpp",
+        "http://localhost:1234/v1",
+    )
+
+    assert errors == []
+
+
+@pytest.mark.unit
 def test_validate_llamacpp_inputs_rejects_default_openai_base_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -937,22 +937,22 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=1.1.14,<2.0.0" },
     { name = "langgraph", specifier = ">=1.0.10,<2.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.3,<4.0.0" },
-    { name = "llama-index", specifier = ">=0.14.12,<0.15.0" },
-    { name = "llama-index-core", marker = "extra == 'llama'", specifier = ">=0.14.12,<0.15.0" },
-    { name = "llama-index-embeddings-clip", specifier = ">=0.5.1,<0.6.0" },
-    { name = "llama-index-embeddings-fastembed", specifier = ">=0.5.0,<0.6.0" },
-    { name = "llama-index-embeddings-huggingface", specifier = ">=0.6.1,<0.7.0" },
-    { name = "llama-index-embeddings-openai", specifier = ">=0.5.1,<0.6.0" },
+    { name = "llama-index", specifier = ">=0.14.21,<0.15.0" },
+    { name = "llama-index-core", marker = "extra == 'llama'", specifier = ">=0.14.21,<0.15.0" },
+    { name = "llama-index-embeddings-clip", specifier = ">=0.6.0,<0.7.0" },
+    { name = "llama-index-embeddings-fastembed", specifier = ">=0.6.0,<0.7.0" },
+    { name = "llama-index-embeddings-huggingface", specifier = ">=0.7.0,<0.8.0" },
+    { name = "llama-index-embeddings-openai", specifier = ">=0.6.0,<0.7.0" },
     { name = "llama-index-graph-stores-kuzu", marker = "extra == 'graph'", specifier = ">=0.9.1,<1.0.0" },
     { name = "llama-index-llms-ollama", specifier = ">=0.9.1,<1.0.0" },
-    { name = "llama-index-llms-openai", specifier = ">=0.6.13,<0.7.0" },
-    { name = "llama-index-llms-openai-like", specifier = ">=0.6.0,<0.7.0" },
+    { name = "llama-index-llms-openai", specifier = ">=0.7.7,<0.8.0" },
+    { name = "llama-index-llms-openai-like", specifier = ">=0.7.2,<0.8.0" },
     { name = "llama-index-observability-otel", marker = "extra == 'observability'", specifier = ">=0.2.1,<0.3.0" },
     { name = "llama-index-postprocessor-colpali-rerank", marker = "extra == 'multimodal'", specifier = "==0.3.1" },
-    { name = "llama-index-readers-file", specifier = ">=0.5.6,<0.6.0" },
-    { name = "llama-index-storage-kvstore-duckdb", specifier = ">=0.2.1,<0.3.0" },
-    { name = "llama-index-vector-stores-duckdb", specifier = ">=0.5.1,<0.6.0" },
-    { name = "llama-index-vector-stores-qdrant", specifier = ">=0.9.0,<0.10.0" },
+    { name = "llama-index-readers-file", specifier = ">=0.6.0,<0.7.0" },
+    { name = "llama-index-storage-kvstore-duckdb", specifier = ">=0.3.0,<0.4.0" },
+    { name = "llama-index-vector-stores-duckdb", specifier = ">=0.6.0,<0.7.0" },
+    { name = "llama-index-vector-stores-qdrant", specifier = ">=0.10.0,<0.11.0" },
     { name = "loguru", specifier = ">=0.7.3,<1.0.0" },
     { name = "ollama", specifier = "==0.6.2" },
     { name = "openai", specifier = ">=2.8.0,<3.0.0" },
@@ -2121,68 +2121,18 @@ wheels = [
 ]
 
 [[package]]
-name = "llama-cloud"
-version = "0.1.35"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "httpx" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/72/816e6e900448e1b4a8137d90e65876b296c5264a23db6ae888bd3e6660ba/llama_cloud-0.1.35.tar.gz", hash = "sha256:200349d5d57424d7461f304cdb1355a58eea3e6ca1e6b0d75c66b2e937216983", size = 106403, upload-time = "2025-07-28T17:22:06.41Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/d2/8d18a021ab757cea231428404f21fe3186bf1ebaac3f57a73c379483fd3f/llama_cloud-0.1.35-py3-none-any.whl", hash = "sha256:b7abab4423118e6f638d2f326749e7a07c6426543bea6da99b623c715b22af71", size = 303280, upload-time = "2025-07-28T17:22:04.946Z" },
-]
-
-[[package]]
-name = "llama-cloud-services"
-version = "0.6.54"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "llama-cloud" },
-    { name = "llama-index-core" },
-    { name = "platformdirs" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tenacity" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/0c/8ca87d33bea0340a8ed791f36390112aeb29fd3eebfd64b6aef6204a03f0/llama_cloud_services-0.6.54.tar.gz", hash = "sha256:baf65d9bffb68f9dca98ac6e22908b6675b2038b021e657ead1ffc0e43cbd45d", size = 53468, upload-time = "2025-08-01T20:09:20.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/48/4e295e3f791b279885a2e584f71e75cbe4ac84e93bba3c36e2668f60a8ac/llama_cloud_services-0.6.54-py3-none-any.whl", hash = "sha256:07f595f7a0ba40c6a1a20543d63024ca7600fe65c4811d1951039977908997be", size = 63874, upload-time = "2025-08-01T20:09:20.076Z" },
-]
-
-[[package]]
 name = "llama-index"
-version = "0.14.16"
+version = "0.14.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llama-index-cli" },
     { name = "llama-index-core" },
     { name = "llama-index-embeddings-openai" },
-    { name = "llama-index-indices-managed-llama-cloud" },
     { name = "llama-index-llms-openai" },
-    { name = "llama-index-readers-file" },
-    { name = "llama-index-readers-llama-parse" },
     { name = "nltk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/43/440cbd852b9372fd392cc81f72df75f17d6dfbe93a427c5911a3400ea168/llama_index-0.14.16.tar.gz", hash = "sha256:266c9b066f2eaee584188bbdb440ed4fd9ad41694c6c9c55c5f15e55eb9dcbc2", size = 9048, upload-time = "2026-03-10T19:20:29.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/8a/472a6ae2c8b4cea977913509e034837ae9f030dcab7027c33ddd4418d746/llama_index-0.14.21.tar.gz", hash = "sha256:99244cbdc7f486aa329c7007faa168085b19eff786ee0c4d246db1cba0f4922b", size = 8565, upload-time = "2026-04-21T00:18:46.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/98/12ff971b3b5f4f82153adb7f5528a276f42aafcdd6193392c43998dd32de/llama_index-0.14.16-py3-none-any.whl", hash = "sha256:cb98fece42d485f52ca847d3d16af61984fdeb7f4c0793a069357ac6eb8293ce", size = 7847, upload-time = "2026-03-10T19:20:31.151Z" },
-]
-
-[[package]]
-name = "llama-index-cli"
-version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llama-index-core" },
-    { name = "llama-index-embeddings-openai" },
-    { name = "llama-index-llms-openai" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/84/41e820efffbe327c38228d3b37fe42512a37e0c3ee4ff6bf97a394e9577a/llama_index_cli-0.5.3.tar.gz", hash = "sha256:ebaf39e785efbfa8d50d837f60cb0f95125c04bf73ed1f92092a2a5f506172f8", size = 24821, upload-time = "2025-09-29T18:03:10.798Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/81/b7b3778aa8662913760fbbee77578daf4407aeaa677ccbf0125c4cfa2e67/llama_index_cli-0.5.3-py3-none-any.whl", hash = "sha256:7deb1e953e582bd885443881ce8bd6ab2817b594fef00079dce9993c47d990f7", size = 28173, upload-time = "2025-09-29T18:03:10.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e4/caa044a84834198363c7342df1480bade423d862509c620846ef3ed2116e/llama_index-0.14.21-py3-none-any.whl", hash = "sha256:d3a13b7d4dde35688d2295a0381d65d1c8f3b69b51bed07c7158e027c00e9480", size = 7114, upload-time = "2026-04-21T00:18:48.06Z" },
 ]
 
 [[package]]
@@ -2226,53 +2176,53 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-clip"
-version = "0.5.1"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/01/7f8a2c62eac5a182e779280344b527a1a4732d1d56341168665916b669e9/llama_index_embeddings_clip-0.5.1.tar.gz", hash = "sha256:0783326029d32f4aa8a1558017fa1467d908abb5aff8fd5e738f26362a313aca", size = 4217, upload-time = "2025-09-08T20:15:42.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/13/baf7a6fea35922533bf9c11bffe7d70547df8e5eb10abd73ca9b1835fed7/llama_index_embeddings_clip-0.6.0.tar.gz", hash = "sha256:18fa7f2fee2d4bcb35351d02508ddb82ff32953b867e92a3d816eac5c129ff12", size = 4215, upload-time = "2026-03-12T20:19:01.447Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/2e/14f03fd7bd62193be292a06aaa7ecee4b3b484b127f525e0ad4ea570b73d/llama_index_embeddings_clip-0.5.1-py3-none-any.whl", hash = "sha256:3aa3b0a34a7bf519b676ee30e2ebfc0ad75f92efa7be47f4fca7ec58b5d7478a", size = 3793, upload-time = "2025-09-08T20:15:41.621Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8a/37233c0dff491b475589846095588af8004c2692876d20718249101bb7f3/llama_index_embeddings_clip-0.6.0-py3-none-any.whl", hash = "sha256:1d6552b38f7a2e2ac7f476383b4598f1a5dab6e8d41c86adc57e94345c7e3d9c", size = 3789, upload-time = "2026-03-12T20:19:00.791Z" },
 ]
 
 [[package]]
 name = "llama-index-embeddings-fastembed"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/6a/ebe898dd830446ada662037c55d6a149e7a66fbe19ac14f527ae7d5e271b/llama_index_embeddings_fastembed-0.5.0.tar.gz", hash = "sha256:d550d617ca94393c6d8e6ee1f39a7e203586458d7bd73108fd7d242f875fd6c0", size = 4125, upload-time = "2025-09-16T02:42:36.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4f/c7b8ad88de03b432e7b91c6dbda546f577ee750c25f0f1bb837fecbe68a8/llama_index_embeddings_fastembed-0.6.0.tar.gz", hash = "sha256:819a4349e2c49fcd4deabcc873d51da7bf937cb85d81331185b5226137aab2df", size = 4124, upload-time = "2026-03-12T20:19:22.967Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/56/25ddb7746ba2e96ac36fe9a4e4b5a7dbb3437e85b4a6158cd9b0e4e472fb/llama_index_embeddings_fastembed-0.5.0-py3-none-any.whl", hash = "sha256:718107a5a3798f668d1ae0c40812274faacf1f3d62fd9f0cbbfadfd220fe7e16", size = 3760, upload-time = "2025-09-16T02:42:35.666Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e9/6f21f164bed8772bc038cd30897ddff2c18ce48c4aa207b5184e51aee88c/llama_index_embeddings_fastembed-0.6.0-py3-none-any.whl", hash = "sha256:c3277d748fc6ab730e613b89af4da81cb4f2bbd66d91995890d0c00235922f70", size = 3759, upload-time = "2026-03-12T20:19:23.608Z" },
 ]
 
 [[package]]
 name = "llama-index-embeddings-huggingface"
-version = "0.6.1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "llama-index-core" },
     { name = "sentence-transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/a0/77beca4ed28af68db6ab9c647b3fa75fae905d33ace96e91010cc9b96027/llama_index_embeddings_huggingface-0.6.1.tar.gz", hash = "sha256:3b21ffeda22f8221ed55778bb3daed71664ab07b341f1dd2f408963bd20355b9", size = 8694, upload-time = "2025-09-08T20:25:27.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b3/faa44f7c9edaaefb6f7e1d8a306433c4ccc5ea5bde92302bec149e62b838/llama_index_embeddings_huggingface-0.7.0.tar.gz", hash = "sha256:da8a2a65df9404112c4430dfada09d4f846ba165197a25dbe77f734014c56a87", size = 8692, upload-time = "2026-03-12T20:20:31.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/b0/4d327cb2f2e039606feb9345b4de975090b9659c4ee84b00443bb149a80d/llama_index_embeddings_huggingface-0.6.1-py3-none-any.whl", hash = "sha256:b63990cf71ee7a36c51f36657133fcf76130e9bf5dcf9eb5a73a5087106d6881", size = 8903, upload-time = "2025-09-08T20:25:27.038Z" },
+    { url = "https://files.pythonhosted.org/packages/25/86/dc43deab70f19db4fcdd82337e18b7f5b828478c486d6308cea10def87c5/llama_index_embeddings_huggingface-0.7.0-py3-none-any.whl", hash = "sha256:cae7e4ffddc1fecb34b83425a00679f338ce03ad0a7f3aca6b927136d6af7131", size = 8904, upload-time = "2026-03-12T20:20:32.449Z" },
 ]
 
 [[package]]
 name = "llama-index-embeddings-openai"
-version = "0.5.1"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-core" },
     { name = "openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/36/90336d054a5061a3f5bc17ac2c18ef63d9d84c55c14d557de484e811ea4d/llama_index_embeddings_openai-0.5.1.tar.gz", hash = "sha256:1c89867a48b0d0daa3d2d44f5e76b394b2b2ef9935932daf921b9e77939ccda8", size = 7020, upload-time = "2025-09-08T20:17:44.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/52/eb56a4887501651fb17400f7f571c1878109ff698efbe0bbac9165a5603d/llama_index_embeddings_openai-0.6.0.tar.gz", hash = "sha256:eb3e6606be81cb89125073e23c97c0a6119dabb4827adbd14697c2029ad73f29", size = 7629, upload-time = "2026-03-12T20:21:27.234Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/4a/8ab11026cf8deff8f555aa73919be0bac48332683111e5fc4290f352dc50/llama_index_embeddings_openai-0.5.1-py3-none-any.whl", hash = "sha256:a2fcda3398bbd987b5ce3f02367caee8e84a56b930fdf43cc1d059aa9fd20ca5", size = 7011, upload-time = "2025-09-08T20:17:44.015Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d1/4bb0b80f4057903110060f617ef519197194b3ff5dd6153d850c8f5676fa/llama_index_embeddings_openai-0.6.0-py3-none-any.whl", hash = "sha256:039bb1007ad4267e25ddb89a206dfdab862bfb87d58da4271a3919e4f9df4d61", size = 7666, upload-time = "2026-03-12T20:21:28.079Z" },
 ]
 
 [[package]]
@@ -2286,20 +2236,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/3c/1f0775d36e2b8e8d35dcb05e2bf572ff4d441ca5125121400d3b26162a2e/llama_index_graph_stores_kuzu-0.9.1.tar.gz", hash = "sha256:3cadf595aa04f46dc758ca782294dba1a8cff33f20eb95ef09ab8bdcb655f39e", size = 11917, upload-time = "2025-09-08T20:44:25.007Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/34/27b0d91154937c743f65eeba91b150acef3eceb3a5ab635bc535bef9ea49/llama_index_graph_stores_kuzu-0.9.1-py3-none-any.whl", hash = "sha256:619f08541bbbfb4da8f01ab7df3bec9089181cd3f81ca30491184bd412ca3207", size = 12689, upload-time = "2025-09-08T20:44:24.254Z" },
-]
-
-[[package]]
-name = "llama-index-indices-managed-llama-cloud"
-version = "0.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecated" },
-    { name = "llama-cloud" },
-    { name = "llama-index-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/4a/79044fcb3209583d1ffe0c2a7c19dddfb657a03faeb9fe0cf5a74027e646/llama_index_indices_managed_llama_cloud-0.9.4.tar.gz", hash = "sha256:b5e00752ab30564abf19c57595a2107f5697c3b03b085817b4fca84a38ebbd59", size = 15146, upload-time = "2025-09-08T20:29:58.673Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/6a/0e33245df06afc9766c46a1fe92687be8a09da5d0d0128bc08d84a9f5efa/llama_index_indices_managed_llama_cloud-0.9.4-py3-none-any.whl", hash = "sha256:535a08811046803ca6ab7f8e9d510e926aa5306608b02201ad3d9d21701383bc", size = 17005, upload-time = "2025-09-08T20:29:57.876Z" },
 ]
 
 [[package]]
@@ -2330,28 +2266,28 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-openai"
-version = "0.6.26"
+version = "0.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-core" },
     { name = "openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/5e/a7a47d46dc2eb30953d83654112c8af6f61821ca78ef3ea22e30729aac3a/llama_index_llms_openai-0.6.26.tar.gz", hash = "sha256:3474602ecbc30c88a8b585cfd5737891d45da78251a5e067c4dbc2d3cc3d08db", size = 27262, upload-time = "2026-03-05T02:53:50.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/38/3d55e9f9af237df6c92e75b824ad85039d6dac386237b519b0dab619288c/llama_index_llms_openai-0.7.7.tar.gz", hash = "sha256:ae9d6fa5ff1982e218d404c328b883a276c12374e1b12d81101ac254cbe569d1", size = 27474, upload-time = "2026-04-28T19:09:34.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/8a/f46f59279c078b001374813f69987b43b7c3bd9df01981af545cf2d954d7/llama_index_llms_openai-0.6.26-py3-none-any.whl", hash = "sha256:2062ef505676d0a1c7c116c138c2f890aa7653619fc3ca697e47df7bd2ef8b3f", size = 28330, upload-time = "2026-03-05T02:53:40.421Z" },
+    { url = "https://files.pythonhosted.org/packages/33/66/fc6818ea699c8cfd0ae780a1c0f04389458bab8a895ac5ff17bfc47e7559/llama_index_llms_openai-0.7.7-py3-none-any.whl", hash = "sha256:d7ee68235d2a86c249d7f22e8608aac9425c14ae894140e70498db9aa3b376b5", size = 28544, upload-time = "2026-04-28T19:09:35.096Z" },
 ]
 
 [[package]]
 name = "llama-index-llms-openai-like"
-version = "0.6.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-core" },
     { name = "llama-index-llms-openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/3c/ae4f56a95c926b6c6c030ec4a235147824a11f8979076173fdd6c90a875f/llama_index_llms_openai_like-0.6.0.tar.gz", hash = "sha256:6938cfed62c77876ba43f26519aabf555775fd8e0e7e1af2ddf37a9fc91dca32", size = 5178, upload-time = "2026-01-30T21:13:11.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a3/16410b28d131aa113ada79f856b78cb68a8e92a1e27255ea9c36c27a5dec/llama_index_llms_openai_like-0.7.2.tar.gz", hash = "sha256:ed9ff73f975dce470f98ac61c982151ba78eedfa3fb9b03894bc1d1312b213ff", size = 5389, upload-time = "2026-04-23T23:05:32.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/19/018966087d11cab287cb3a37e53c79a045b6ae8442d9eb325d1b5accb70a/llama_index_llms_openai_like-0.6.0-py3-none-any.whl", hash = "sha256:6d97260787ea5a2e6ad15fb547ec5c606b87775dcf9903a698e4c7e9893b367e", size = 4860, upload-time = "2026-01-30T21:13:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0c/fdddaee5391d915d3d568d2d8dbdb7c95647e65bb94d4ddb31d47cef5daf/llama_index_llms_openai_like-0.7.2-py3-none-any.whl", hash = "sha256:1f45a7b1cec8fb3f5997684327ffe6c19f93e789c2fff35dc5522465850faf0b", size = 6602, upload-time = "2026-04-23T23:05:31.708Z" },
 ]
 
 [[package]]
@@ -2388,7 +2324,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-file"
-version = "0.5.6"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -2398,27 +2334,14 @@ dependencies = [
     { name = "pypdf" },
     { name = "striprtf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/e5/dccfb495dbc40f50fcfb799db2287ac5dca4a16a3b09bae61a4ccb1788d3/llama_index_readers_file-0.5.6.tar.gz", hash = "sha256:1c08b14facc2dfe933622aaa26dc7d2a7a6023c42d3db896a2c948789edaf1ea", size = 32535, upload-time = "2025-12-24T16:04:16.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/b9/5d5ecb81febd544a04b38f4ef7d3a69ec0625204f3c0f3d8200b70f16c2d/llama_index_readers_file-0.6.0.tar.gz", hash = "sha256:ff366d6ff5ecb7119275ac859310d8b672d8b6b3261afae02f4084fce9076bd0", size = 32537, upload-time = "2026-03-12T20:34:32.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/c3/8d28eaa962e073e6735d80847dda9fd3525cb9ff5974ae82dd20621a5a02/llama_index_readers_file-0.5.6-py3-none-any.whl", hash = "sha256:32e83f9adb4e4803e6c7cef746c44fa0949013b1cb76f06f422e9491d198dbda", size = 51832, upload-time = "2025-12-24T16:04:17.307Z" },
-]
-
-[[package]]
-name = "llama-index-readers-llama-parse"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llama-index-core" },
-    { name = "llama-parse" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/77/5bfaab20e6ec8428dbf2352e18be550c957602723d69383908176b5686cd/llama_index_readers_llama_parse-0.5.1.tar.gz", hash = "sha256:2b78b73faa933e30e6c69df351e4e9f36dfe2ae142e2ab3969ddd2ac48930e37", size = 3858, upload-time = "2025-09-08T20:41:29.201Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/81/52410c7245dcbf1a54756a9ce3892cdd167ec0b884d696de1304ca3f452e/llama_index_readers_llama_parse-0.5.1-py3-none-any.whl", hash = "sha256:0d41450ed29b0c49c024e206ef6c8e662b1854e77a1c5faefed3b958be54f880", size = 3203, upload-time = "2025-09-08T20:41:28.438Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ab/ff4b2e14a63708abc0115ccb13e41b324972c0346d9b82d1fb8dbb77873a/llama_index_readers_file-0.6.0-py3-none-any.whl", hash = "sha256:1026d94f2d5902152373bc2c3b7caa7e216d956620b22d510e516850b6a7440d", size = 51830, upload-time = "2026-03-12T20:34:33.315Z" },
 ]
 
 [[package]]
 name = "llama-index-storage-kvstore-duckdb"
-version = "0.2.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "duckdb" },
@@ -2426,37 +2349,37 @@ dependencies = [
     { name = "llama-index-vector-stores-duckdb" },
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/1d/93cc9addf4759605b473fb5d01371e2cab62cbc374e469365cf1e2b7fb91/llama_index_storage_kvstore_duckdb-0.2.1.tar.gz", hash = "sha256:efb277f5c70b8877818324c010144120807cb355207283cd350f9319b82640dd", size = 5360, upload-time = "2025-09-08T20:39:26.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c2/1c86f4802e751d4cdc6dca10e4fd23b2ab3a9b51da43c27808e0d6b6f26f/llama_index_storage_kvstore_duckdb-0.3.0.tar.gz", hash = "sha256:743dacf7a215757ecc46e7e1fe2c03d3d509a3ad6ac83fca4f20f2ab56134122", size = 5361, upload-time = "2026-03-12T20:42:08.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/d9/dd9257719fe1e1407b6c340662eebeb238d3db6a70d0dd81c39284e6b559/llama_index_storage_kvstore_duckdb-0.2.1-py3-none-any.whl", hash = "sha256:8d3df1ad0e41e5ca437b5fe30d7561f17b106916b50d33ad5f738a1bdac828f6", size = 4956, upload-time = "2025-09-08T20:39:25.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d2/39e3aaae0ba82ee2e449a78c7a9d8609f68517e7a9ca79e0ab39e9a2ffb4/llama_index_storage_kvstore_duckdb-0.3.0-py3-none-any.whl", hash = "sha256:c95d6257caaa2e8860af2e0f4edbe21db40866aa25e7c93e1bcbb1df453ac201", size = 4954, upload-time = "2026-03-12T20:42:07.791Z" },
 ]
 
 [[package]]
 name = "llama-index-vector-stores-duckdb"
-version = "0.5.1"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "duckdb" },
     { name = "llama-index-core" },
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/e8/f4fcbbcc5635844bfd6e025d102f09c9b791f0f976164cddd656bdfbab03/llama_index_vector_stores_duckdb-0.5.1.tar.gz", hash = "sha256:e04d63cc12c1f5fd27fce9dd68f805e7c70f93c94e0cda01e12fcd2c68a108b3", size = 8009, upload-time = "2025-09-08T20:41:34.851Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/de/c27fae4ad869685d4afac8d938cc29fc1095278de27d4944cd84b2449d3f/llama_index_vector_stores_duckdb-0.6.0.tar.gz", hash = "sha256:333273a6fc14a7dedb61cdaaf63e30be292407eac20d0dc1b929153f5710a131", size = 8010, upload-time = "2026-03-12T20:46:20.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/bf/471aa699029a6d6fa0cb4cc66963f71d69d363c1f3340794a849d02961af/llama_index_vector_stores_duckdb-0.5.1-py3-none-any.whl", hash = "sha256:ac8058a9accd624afcf60548956251f0f0d4ede84c1601cbeec646ca4d918316", size = 7744, upload-time = "2025-09-08T20:41:34.101Z" },
+    { url = "https://files.pythonhosted.org/packages/af/2b/cec901b710e6e6baa799ec094259afed204bc937f45148649c5337b439f0/llama_index_vector_stores_duckdb-0.6.0-py3-none-any.whl", hash = "sha256:2aa4a59a05959f4c32cb2965e6aae1242d4f37621e9848a1f2b488f9f106fd19", size = 7742, upload-time = "2026-03-12T20:46:20.071Z" },
 ]
 
 [[package]]
 name = "llama-index-vector-stores-qdrant"
-version = "0.9.2"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "llama-index-core" },
     { name = "qdrant-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/5b/4957f112b2405e960f425f92e337f1ad22315c0cda50c5117575b0e08d10/llama_index_vector_stores_qdrant-0.9.2.tar.gz", hash = "sha256:c7f8138a0f4f79bed79a32b7c875d2766849b02a779617e55b8d1feb1a9e605a", size = 14698, upload-time = "2026-03-06T11:20:52.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/ff/f1ce3444c65cf3aff1edd4810e2736f9d81512cd5e2565cd7d341e17fbba/llama_index_vector_stores_qdrant-0.10.0.tar.gz", hash = "sha256:173855ff82fffedda5b24c2561f8a6dcd9da24318143188de85470f6667a84ea", size = 14699, upload-time = "2026-03-12T20:47:56.99Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/5e137cee4acf04ae49e6be865cf732174353439377ba65999e43b91ad978/llama_index_vector_stores_qdrant-0.9.2-py3-none-any.whl", hash = "sha256:631139e3dc84a831e949758f99b0858a53c835c5a5878a68d676b3eb579c824f", size = 14953, upload-time = "2026-03-06T11:20:55.127Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/6486b04a867e6ce5fdd3b838146a9e951a42668ea8fd7fcee9d0e6c41c9f/llama_index_vector_stores_qdrant-0.10.0-py3-none-any.whl", hash = "sha256:a883c9bd3d301b434fdf1645a5118b18db0b429d4011ba275ce23a69297606c6", size = 14967, upload-time = "2026-03-12T20:47:57.921Z" },
 ]
 
 [[package]]
@@ -2471,18 +2394,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/ec/05f3db99a2e6e252e3939e7751cad2fb1322dc6d32f4cf5c795cf7ddcad3/llama_index_workflows-2.20.0.tar.gz", hash = "sha256:df2760fea9e100c97a4e919d255461e344413acac4382d17d8217337806e4772", size = 97410, upload-time = "2026-04-24T14:54:41.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/5f/385231406d777cb4b608fd8ebe3577dbd90962770717181e6b91b44fb1b8/llama_index_workflows-2.20.0-py3-none-any.whl", hash = "sha256:36f6b6ace77f837d9907078aea7e830251afe96a58daecff5ed090c88c55095d", size = 121238, upload-time = "2026-04-24T14:54:40.455Z" },
-]
-
-[[package]]
-name = "llama-parse"
-version = "0.6.54"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llama-cloud-services" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/f6/93b5d123c480bc8c93e6dc3ea930f4f8df8da27f829bb011100ba3ce23dc/llama_parse-0.6.54.tar.gz", hash = "sha256:c707b31152155c9bae84e316fab790bbc8c85f4d8825ce5ee386ebeb7db258f1", size = 3577, upload-time = "2025-08-01T20:09:23.762Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/50/c5ccd2a50daa0a10c7f3f7d4e6992392454198cd8a7d99fcb96cb60d0686/llama_parse-0.6.54-py3-none-any.whl", hash = "sha256:c66c8d51cf6f29a44eaa8595a595de5d2598afc86e5a33a4cebe5fe228036920", size = 4879, upload-time = "2025-08-01T20:09:22.651Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Restores first-class GGUF llama.cpp UX through `llama-server` / OpenAI-compatible HTTP, keeping the secure server-first design.
- Adds a shared runtime probe that checks llama.cpp `/health` before `/v1/models` and reuses it from Settings.
- Adds in-app llama.cpp launch guidance plus README/config/spec docs.
- Upgrades the related LlamaIndex runtime/integration wave to latest compatible versions.

Closes #84

## Dependency changes
- `llama-index` `0.14.16` -> `0.14.21`
- `llama-index-llms-openai` `0.6.26` -> `0.7.7`
- `llama-index-llms-openai-like` `0.6.0` -> `0.7.2`
- LlamaIndex embeddings/readers/vector-store/duckdb integrations upgraded to current compatible lines.
- Removed now-unneeded LlamaCloud/LlamaParse transitive packages from the resolved graph.
- Confirmed `llama-cpp-python` and `diskcache` remain absent.

## Validation
- `uv sync --all-extras --dev --python 3.12`
- `uv run ruff check .`
- `uv run pyright --threads 4`
- `uv run pytest` -> `1360 passed, 39 skipped`
- `uv pip check`

## Research notes
- LlamaIndex docs confirm `OpenAILike` is the intended wrapper for OpenAI-compatible servers.
- llama.cpp docs confirm `llama-server` exposes `/health`, `/v1/models`, and OpenAI-compatible `/v1/chat/completions`.
- Source inspection confirmed `llama-cpp-python==0.3.21` still imports/depends on `diskcache`, so in-process bindings stay out of the locked install path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved LLM runtime probing with separate health and models checks; settings UI shows distinct Health and Models status and messages, plus llama.cpp server guidance.

* **Documentation**
  * Updated README, configuration docs, spec and .env examples with llama.cpp/OpenAI-compatible server setup, alias and /v1 normalization guidance.

* **Bug Fixes**
  * Tightened validation to reject disallowed OpenAI API URLs for local llama.cpp configs.

* **Tests**
  * Added unit tests for runtime probing and settings validation.

* **Chores**
  * Bumped LlamaIndex-related dependency ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->