### PR TITLE
fix(operations): harden v2 cleanup boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,11 @@ library update.
   from local automation. Reconcile `.env` against the tracked `.env.example`;
   removed agent fallback, UI, cache-limit, monitoring-limit, and legacy
   GraphRAG knobs no longer change runtime behavior.
+- Do not point v2 at retained pre-v2 data or Qdrant state when
+  `data/.deployment-id` is absent. V2 cannot safely prove ownership of that
+  state and does not adopt it in place. Preserve the old state and follow the
+  [pre-v2 no-adoption procedure](docs/developers/operations-guide.md#preserve-activation-identity-and-journals).
+  Never fabricate a deployment identity.
 - Stop DocMind before the v2 upgrade. V1 stored raw public thread IDs, while v2 hashes each `(user_id, public_thread_id)` pair for LangGraph checkpoints. V2 has no checkpoint-key migration. Startup rejects a Chat DB that contains raw v1 checkpoint identities. Archive the database and its write-ahead log (WAL) sidecars, then let v2 create a fresh database:
 
   ```bash

--- a/docs/developers/operations-guide.md
+++ b/docs/developers/operations-guide.md
@@ -174,6 +174,13 @@ directory. If the file is missing or invalid after `CURRENT` or a canonical
 snapshot exists, startup fails closed instead of assigning a new owner. Preserve
 the file with the entire data directory and every recovery point.
 
+Retained pre-v2 snapshots and Qdrant state without `data/.deployment-id` cannot
+be adopted in place because v2 cannot prove their deployment ownership. Stop
+the old deployment and preserve and back up both its full data directory and
+Qdrant service or volume. Configure v2 with a fresh, empty data directory and
+Qdrant boundary, then re-ingest the source corpus. Do not fabricate an identity,
+and do not delete the old state until its backup is verified.
+
 DocMind resolves source and snapshot crash journals while it holds the snapshot
 writer lock. Promotion journals under `data/.upload-transactions/` either finish
 the exact generation named by `CURRENT` or roll promoted files back to pending

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,7 +72,10 @@ uv run pytest tests/unit/processing/test_parser_contract.py -vv --no-cov
   an empty `warnings` list. Follow the operations guide for restore.
 - `cleanup_collections.py`: inspect deployment-owned orphan Qdrant generations
   after stopping every DocMind reader and writer. It is dry-run by default;
-  `--delete` is an explicit second step.
+  `--delete` is an explicit second step. It does not adopt pre-v2 state that
+  lacks `data/.deployment-id`; follow the
+  [pre-v2 no-adoption procedure](../docs/developers/operations-guide.md#preserve-activation-identity-and-journals)
+  instead of fabricating an identity.
 - `qdrant_schema.py`: inspect or rebuild an empty canonical Qdrant collection.
 - `qdrant_fusion_smoke.py`: prove client support for native RRF and DBSF.
 - `start_qdrant_local.sh`: start the supported local Qdrant service.

--- a/scripts/cleanup_collections.py
+++ b/scripts/cleanup_collections.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from qdrant_client import QdrantClient
 
-from src.config import settings
+from src.config import bootstrap_settings, settings
 from src.persistence.collection_cleanup import cleanup_orphan_collections
 from src.utils.storage import get_client_config
 
@@ -40,30 +40,42 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    client = QdrantClient(**get_client_config(settings))
+    client: QdrantClient | None = None
+    result: dict[str, object] | None = None
+    error: Exception | None = None
     try:
-        summary = cleanup_orphan_collections(
+        bootstrap_settings()
+        client = QdrantClient(**get_client_config(settings))
+        result = cleanup_orphan_collections(
             client,
             delete=bool(args.delete),
             cfg=settings,
-        )
+        ).as_dict()
     except Exception as exc:
+        error = exc
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception as exc:
+                if error is None:
+                    error = exc
+
+    if error is not None:
+        error_payload: dict[str, object] = {
+            "status": "error",
+            "error_type": type(error).__name__,
+            "error": str(error),
+        }
+        if result is not None:
+            error_payload["result"] = result
         print(
-            json.dumps(
-                {
-                    "status": "error",
-                    "error_type": type(exc).__name__,
-                    "error": str(exc),
-                },
-                sort_keys=True,
-            ),
+            json.dumps(error_payload, sort_keys=True),
             file=sys.stderr,
         )
         return 2
-    finally:
-        client.close()
 
-    print(json.dumps(summary.as_dict(), sort_keys=True))
+    print(json.dumps(result, sort_keys=True))
     return 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,10 @@ def _streamlit_disable_repl_detection() -> Generator[None]:
 
 
 @pytest.fixture(autouse=True)
-def _reset_docmind_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+def _reset_docmind_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     """Keep tests deterministic even when a developer `.env` exists.
 
     Pytest runs in the developer's working tree. Some environments or tools may
@@ -94,7 +97,10 @@ def _reset_docmind_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     from src.config.settings import settings as app_settings
 
     reset_bootstrap_state()
-    app_settings.__init__(_env_file=None)  # type: ignore[arg-type]
+    app_settings.__init__(
+        data_dir=tmp_path / "data",
+        _env_file=None,  # type: ignore[arg-type]
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/config/test_settings_isolation.py
+++ b/tests/unit/config/test_settings_isolation.py
@@ -1,0 +1,16 @@
+"""Regression coverage for the process-global test settings boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.config import settings
+
+pytestmark = pytest.mark.unit
+
+
+def test_global_settings_data_root_is_isolated(tmp_path: Path) -> None:
+    """Keep process-global writes inside the current test's temp directory."""
+    assert settings.data_dir == tmp_path / "data"

--- a/tests/unit/scripts/test_cleanup_collections.py
+++ b/tests/unit/scripts/test_cleanup_collections.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -11,18 +13,120 @@ from scripts import cleanup_collections as command
 
 
 class _Client:
-    def __init__(self, **_kwargs: object) -> None:
+    def __init__(
+        self,
+        *,
+        close_error: Exception | None = None,
+        **_kwargs: object,
+    ) -> None:
         self.closed = False
+        self.close_error = close_error
 
     def close(self) -> None:
         self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
 
 
-def test_cli_requires_explicit_quiescence_acknowledgement() -> None:
+@pytest.fixture(autouse=True)
+def _stub_bootstrap_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command, "bootstrap_settings", lambda: None)
+
+
+def _stub_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    client: _Client,
+    cleanup: Callable[..., object],
+) -> None:
+    monkeypatch.setattr(command, "QdrantClient", lambda **_kwargs: client)
+    monkeypatch.setattr(command, "get_client_config", lambda _cfg: {})
+    monkeypatch.setattr(command, "cleanup_orphan_collections", cleanup)
+
+
+def _read_error(capsys: pytest.CaptureFixture[str]) -> dict[str, object]:
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    return cast(dict[str, object], json.loads(captured.err))
+
+
+def _record_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    failure_stage: str | None = None,
+) -> list[str]:
+    events: list[str] = []
+
+    def _record(stage: str) -> None:
+        events.append(stage)
+        if failure_stage == stage:
+            raise RuntimeError(f"{stage} failed")
+
+    def _client_config(_cfg: object) -> dict[str, object]:
+        _record("config")
+        return {}
+
+    def _client(**_kwargs: object) -> _Client:
+        _record("client")
+        return _Client()
+
+    def _cleanup(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        _record("cleanup")
+        return SimpleNamespace(as_dict=lambda: {"status": "ok"})
+
+    monkeypatch.setattr(command, "bootstrap_settings", lambda: _record("bootstrap"))
+    monkeypatch.setattr(command, "get_client_config", _client_config)
+    monkeypatch.setattr(command, "QdrantClient", _client)
+    monkeypatch.setattr(command, "cleanup_orphan_collections", _cleanup)
+    return events
+
+
+def test_cli_requires_explicit_quiescence_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    side_effects = _record_lifecycle(monkeypatch)
+
     with pytest.raises(SystemExit) as exc_info:
         command.main([])
 
     assert exc_info.value.code == 2
+    assert side_effects == []
+
+
+def test_cli_bootstraps_before_reading_client_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events = _record_lifecycle(monkeypatch)
+
+    assert command.main(["--confirm-app-stopped"]) == 0
+
+    assert events == ["bootstrap", "config", "client", "cleanup"]
+
+
+@pytest.mark.parametrize(
+    ("failure_stage", "expected_events"),
+    [
+        ("bootstrap", ["bootstrap"]),
+        ("config", ["bootstrap", "config"]),
+        ("client", ["bootstrap", "config", "client"]),
+    ],
+)
+def test_cli_reports_setup_failures_without_tracebacks(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    failure_stage: str,
+    expected_events: list[str],
+) -> None:
+    events = _record_lifecycle(monkeypatch, failure_stage=failure_stage)
+
+    assert command.main(["--confirm-app-stopped"]) == 2
+
+    assert _read_error(capsys) == {
+        "error": f"{failure_stage} failed",
+        "error_type": "RuntimeError",
+        "status": "error",
+    }
+    assert events == expected_events
 
 
 def test_cli_defaults_to_dry_run_and_closes_client(
@@ -30,8 +134,6 @@ def test_cli_defaults_to_dry_run_and_closes_client(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     client = _Client()
-    monkeypatch.setattr(command, "QdrantClient", lambda **_kwargs: client)
-    monkeypatch.setattr(command, "get_client_config", lambda _cfg: {})
     cleanup_calls: list[bool] = []
 
     def _cleanup(_client: object, *, delete: bool, cfg: object) -> SimpleNamespace:
@@ -40,7 +142,7 @@ def test_cli_defaults_to_dry_run_and_closes_client(
         cleanup_calls.append(delete)
         return SimpleNamespace(as_dict=lambda: {"status": "ok", "mode": "dry-run"})
 
-    monkeypatch.setattr(command, "cleanup_orphan_collections", _cleanup)
+    _stub_runtime(monkeypatch, client=client, cleanup=_cleanup)
 
     assert command.main(["--confirm-app-stopped"]) == 0
 
@@ -56,20 +158,51 @@ def test_cli_closes_client_when_cleanup_fails(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    client = _Client()
-    monkeypatch.setattr(command, "QdrantClient", lambda **_kwargs: client)
-    monkeypatch.setattr(command, "get_client_config", lambda _cfg: {})
-    monkeypatch.setattr(
-        command,
-        "cleanup_orphan_collections",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("blocked")),
-    )
+    client = _Client(close_error=RuntimeError("close failed"))
+
+    def _cleanup(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("blocked")
+
+    _stub_runtime(monkeypatch, client=client, cleanup=_cleanup)
 
     assert command.main(["--confirm-app-stopped", "--delete"]) == 2
 
     assert client.closed is True
-    assert json.loads(capsys.readouterr().err) == {
+    assert _read_error(capsys) == {
         "error": "blocked",
         "error_type": "RuntimeError",
+        "status": "error",
+    }
+
+
+def test_cli_reports_close_failure_without_success_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client = _Client(close_error=RuntimeError("close failed"))
+
+    completed_result = {
+        "status": "ok",
+        "mode": "delete",
+        "deleted_collections": ["old-generation"],
+    }
+
+    def _cleanup(
+        *_args: object,
+        delete: bool,
+        **_kwargs: object,
+    ) -> SimpleNamespace:
+        assert delete is True
+        return SimpleNamespace(as_dict=lambda: completed_result)
+
+    _stub_runtime(monkeypatch, client=client, cleanup=_cleanup)
+
+    assert command.main(["--confirm-app-stopped", "--delete"]) == 2
+
+    assert client.closed is True
+    assert _read_error(capsys) == {
+        "error": "close failed",
+        "error_type": "RuntimeError",
+        "result": completed_result,
         "status": "error",
     }

--- a/tests/unit/utils/storage/test_storage_qdrant_schema.py
+++ b/tests/unit/utils/storage/test_storage_qdrant_schema.py
@@ -9,6 +9,8 @@ from typing import Any
 import pytest
 from qdrant_client import models as qmodels
 
+from src.persistence.deployment_identity import get_or_create_deployment_id
+
 
 def test_ensure_hybrid_collection_creates_when_missing(monkeypatch):  # type: ignore[no-untyped-def]
     """Ensure ensure_hybrid_collection creates a new schema when absent."""
@@ -126,6 +128,7 @@ def test_check_hybrid_collection_rejects_non_cosine_dense_vector() -> None:
 def test_check_hybrid_collection_rejects_missing_metadata() -> None:
     """A structurally valid collection without owner metadata is incompatible."""
     smod = importlib.import_module("src.utils.storage")
+    get_or_create_deployment_id(smod.settings.data_dir)
 
     class _Client:
         def collection_exists(self, _name: str) -> bool:


### PR DESCRIPTION
## Summary
- isolate the process-global DocMind settings singleton under each pytest temporary data root
- bootstrap canonical settings before the destructive-capable Qdrant cleanup client and normalize all post-parse lifecycle failures
- preserve completed deletion summaries when client teardown fails
- document the forward-only pre-v2 data and Qdrant migration boundary with one canonical operations procedure

Follow-up to #160 and the v2.0.0 release.

## Verification
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright --threads 4
- uv run pytest tests/unit tests/integration -q --no-cov (1361 passed, 3 skipped)
- uv run python scripts/check_links.py
- npx --yes markdownlint-cli@0.47.0 --disable MD013 MD033 MD041 -- README.md scripts/README.md docs/developers/operations-guide.md
- git diff --check

## Review
Three final read-only stop-gates independently returned ALLOW with no findings across Python/test isolation, destructive operator safety, and minimality/docs SSOT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified upgrade procedures for deployments without a v2 deployment identity.
  * Added guidance to preserve and back up legacy data and Qdrant state before re-ingesting source content.
  * Documented that deployment identities must not be fabricated or used to adopt unverifiable legacy state.

* **Bug Fixes**
  * Improved cleanup command initialization, shutdown handling, and structured error reporting.
  * Cleanup failures now return consistent JSON details and the appropriate exit status.

* **Tests**
  * Strengthened configuration isolation and cleanup error-handling coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->