### PR TITLE
test(ui): isolate AppTest module registry

### DIFF
--- a/tests/integration/ui/conftest.py
+++ b/tests/integration/ui/conftest.py
@@ -9,10 +9,39 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterator
+from types import ModuleType
+from typing import cast
 
 import pytest
 
 _MISSING = object()
+
+
+def _restore_parent_attribute(
+    name: str,
+    parent: object,
+    original: object,
+) -> None:
+    """Restore and verify one target's parent attribute exactly."""
+    parent_name, _, attribute = name.rpartition(".")
+    current_parent = sys.modules.get(parent_name, _MISSING)
+    if (
+        current_parent is not _MISSING
+        and current_parent is not parent
+        and hasattr(current_parent, attribute)
+    ):
+        delattr(current_parent, attribute)
+    if parent is not _MISSING:
+        if original is _MISSING:
+            if hasattr(parent, attribute):
+                delattr(parent, attribute)
+        else:
+            setattr(parent, attribute, original)
+    current_parent = sys.modules.get(parent_name, _MISSING)
+    if current_parent is not _MISSING and current_parent is not parent:
+        assert getattr(current_parent, attribute, _MISSING) is _MISSING
+    if parent is not _MISSING:
+        assert getattr(parent, attribute, _MISSING) is original
 
 
 @pytest.fixture(autouse=True)
@@ -24,9 +53,10 @@ def _stub_chat_embedding_setup(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _reset_router_and_graph_modules() -> Iterator[None]:
+def _reset_router_and_graph_modules() -> Iterator[pytest.MonkeyPatch]:
     """Clear cached modules that these tests patch to avoid order sensitivity."""
     targets = [
+        "llama_index.core",
         "src.agents.coordinator",
         "src.pages.01_chat",
         "src.retrieval.multimodal_fusion",
@@ -38,35 +68,35 @@ def _reset_router_and_graph_modules() -> Iterator[None]:
         "src.utils.storage",
         "src.pages.02_documents",
     ]
-    saved = {name: sys.modules.get(name) for name in targets}
+    saved = {name: sys.modules.get(name, _MISSING) for name in targets}
     parent_attributes: dict[str, tuple[object, object]] = {}
     for name in targets:
         parent_name, _, attribute = name.rpartition(".")
-        parent = sys.modules.get(parent_name)
-        if parent is not None:
-            original = getattr(parent, attribute, _MISSING)
-            parent_attributes[name] = (parent, original)
-            if original is not _MISSING:
-                delattr(parent, attribute)
+        parent = sys.modules.get(parent_name, _MISSING)
+        original = (
+            _MISSING if parent is _MISSING else getattr(parent, attribute, _MISSING)
+        )
+        parent_attributes[name] = (parent, original)
+        if parent is not _MISSING and original is not _MISSING:
+            delattr(parent, attribute)
         sys.modules.pop(name, None)
+    registry_patch = pytest.MonkeyPatch()
     try:
-        yield
+        yield registry_patch
     finally:
+        registry_patch.undo()
         # Restore the pre-test import state so UI tests can't contaminate other
         # test modules that imported these symbols during collection.
         for name in targets:
-            original = saved.get(name)
-            if original is None:
+            original = saved[name]
+            if original is _MISSING:
                 sys.modules.pop(name, None)
             else:
-                sys.modules[name] = original
+                sys.modules[name] = cast(ModuleType, original)
         for name, (parent, original) in parent_attributes.items():
-            attribute = name.rpartition(".")[2]
-            if original is _MISSING:
-                if hasattr(parent, attribute):
-                    delattr(parent, attribute)
-            else:
-                setattr(parent, attribute, original)
+            _restore_parent_attribute(name, parent, original)
+        for name, original in saved.items():
+            assert sys.modules.get(name, _MISSING) is original
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/ui/test_analysis_modes.py
+++ b/tests/integration/ui/test_analysis_modes.py
@@ -26,6 +26,7 @@ pytestmark = pytest.mark.integration
 def chat_analysis_app_test(  # noqa: PLR0915 - complete AppTest boundary fixture
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    _reset_router_and_graph_modules: pytest.MonkeyPatch,
     fake_job_manager,
     fake_job_owner_id,
 ) -> Iterator[AppTest]:
@@ -78,7 +79,9 @@ def chat_analysis_app_test(  # noqa: PLR0915 - complete AppTest boundary fixture
     coord_mod.MultiAgentCoordinator = (  # type: ignore[attr-defined]
         lambda *_, **__: _CoordStub()
     )
-    monkeypatch.setitem(sys.modules, "src.agents.coordinator", coord_mod)
+    _reset_router_and_graph_modules.setitem(
+        sys.modules, "src.agents.coordinator", coord_mod
+    )
 
     @dataclass(frozen=True, slots=True)
     class _ChatSelection:
@@ -92,7 +95,9 @@ def chat_analysis_app_test(  # noqa: PLR0915 - complete AppTest boundary fixture
         thread_id="t", user_id="local"
     )
     chat_sessions_mod.render_time_travel_sidebar = lambda *_, **__: None
-    monkeypatch.setitem(sys.modules, "src.ui.chat_sessions", chat_sessions_mod)
+    _reset_router_and_graph_modules.setitem(
+        sys.modules, "src.ui.chat_sessions", chat_sessions_mod
+    )
 
     # Stub analysis service to keep UI test deterministic and fast under CI+cov.
     import src.analysis.service as analysis_service

--- a/tests/integration/ui/test_app_smoke_flows.py
+++ b/tests/integration/ui/test_app_smoke_flows.py
@@ -94,7 +94,9 @@ def test_app_entrypoint_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def chat_app_smoke(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_router_and_graph_modules: pytest.MonkeyPatch,
 ) -> Generator[AppTest, None, None]:
     """AppTest harness for Chat page with a stub coordinator.
 
@@ -120,7 +122,7 @@ def chat_app_smoke(
 
     mod = ModuleType("src.agents.coordinator")
     mod.MultiAgentCoordinator = _CoordinatorStub  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "src.agents.coordinator", mod)
+    _reset_router_and_graph_modules.setitem(sys.modules, "src.agents.coordinator", mod)
 
     root = Path(__file__).resolve().parents[3]
     page_path = root / "src" / "pages" / "01_chat.py"

--- a/tests/integration/ui/test_chat_autoload_snapshot.py
+++ b/tests/integration/ui/test_chat_autoload_snapshot.py
@@ -23,7 +23,11 @@ from tests.helpers.apptest_utils import apptest_timeout_sec
 
 
 @pytest.fixture
-def chat_app_autoload(tmp_path: Path, monkeypatch) -> AppTest:
+def chat_app_autoload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_router_and_graph_modules: pytest.MonkeyPatch,
+) -> AppTest:
     # Point data_dir to tmp
     from src.config.settings import settings as _settings  # local import
 
@@ -81,7 +85,9 @@ def chat_app_autoload(tmp_path: Path, monkeypatch) -> AppTest:
 
     coord_mod: Any = ModuleType("src.agents.coordinator")
     coord_mod.MultiAgentCoordinator = _CoordinatorStub
-    monkeypatch.setitem(sys.modules, "src.agents.coordinator", coord_mod)
+    _reset_router_and_graph_modules.setitem(
+        sys.modules, "src.agents.coordinator", coord_mod
+    )
 
     @dataclass(frozen=True, slots=True)
     class _ChatSelection:
@@ -95,7 +101,9 @@ def chat_app_autoload(tmp_path: Path, monkeypatch) -> AppTest:
         thread_id="t", user_id="local"
     )
     chat_sessions_mod.render_time_travel_sidebar = lambda *_, **__: None
-    monkeypatch.setitem(sys.modules, "src.ui.chat_sessions", chat_sessions_mod)
+    _reset_router_and_graph_modules.setitem(
+        sys.modules, "src.ui.chat_sessions", chat_sessions_mod
+    )
 
     # Stub LI modules for loader internals
     core_mod: Any = ModuleType("llama_index.core")
@@ -130,7 +138,7 @@ def chat_app_autoload(tmp_path: Path, monkeypatch) -> AppTest:
     core_mod.PropertyGraphIndex = _PropertyGraphIndex
     core_mod.StorageContext = _StorageContext
 
-    monkeypatch.setitem(sys.modules, "llama_index.core", core_mod)
+    _reset_router_and_graph_modules.setitem(sys.modules, "llama_index.core", core_mod)
     monkeypatch.setattr(
         "src.utils.storage.connect_vector_store",
         lambda *_args, **_kwargs: vector_store,
@@ -139,7 +147,9 @@ def chat_app_autoload(tmp_path: Path, monkeypatch) -> AppTest:
     # Stub router factory
     rf_mod: Any = ModuleType("src.retrieval.router_factory")
     rf_mod.build_router_engine = lambda *_, **__: object()
-    monkeypatch.setitem(sys.modules, "src.retrieval.router_factory", rf_mod)
+    _reset_router_and_graph_modules.setitem(
+        sys.modules, "src.retrieval.router_factory", rf_mod
+    )
 
     # Build AppTest for Chat page
     root = Path(__file__).resolve().parents[3]

--- a/tests/integration/ui/test_chat_persistence_time_travel.py
+++ b/tests/integration/ui/test_chat_persistence_time_travel.py
@@ -172,7 +172,11 @@ class _CoordinatorStub:
 
 
 @pytest.fixture
-def chat_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[AppTest]:
+def chat_app(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_router_and_graph_modules: pytest.MonkeyPatch,
+) -> Iterator[AppTest]:
     """Create an AppTest instance for the Chat page with a coordinator stub."""
     from src.config.settings import settings as _settings  # local import
 
@@ -189,7 +193,7 @@ def chat_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[AppTes
 
     mod = ModuleType("src.agents.coordinator")
     mod.MultiAgentCoordinator = _CoordinatorStub  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "src.agents.coordinator", mod)
+    _reset_router_and_graph_modules.setitem(sys.modules, "src.agents.coordinator", mod)
 
     root = Path(__file__).resolve().parents[3]
     page_path = root / "src" / "pages" / "01_chat.py"


### PR DESCRIPTION
## Summary

- give AppTest module stubs a dedicated registry patcher whose undo runs before restoration
- restore exact `sys.modules` and parent-package attribute identities, including originally absent parents
- keep ordinary environment and attribute patches on the standard pytest fixture

Closes #165

## Verification

- `uv run pytest -q` — 1,525 passed, 7 skipped
- focused forward and reverse order — 17 passed each
- pytest-randomly seeds 165, 166, and 167 — 17 passed each
- Ruff format/check and Pyright — green
- two independent post-rebase reviews — ALLOW, no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved isolation and cleanup between UI application test runs.
  * Updated test fixtures to safely replace and restore application modules.
  * Added stricter verification that the Python import state is fully restored after tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->