### PR TITLE
test(isolation): remove randomized global state leaks

### DIFF
--- a/tests/shared_fixtures.py
+++ b/tests/shared_fixtures.py
@@ -30,6 +30,7 @@ from llama_index.core.embeddings import MockEmbedding
 from llama_index.core.llms.llm import LLM
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.schema import NodeWithScore, TextNode
+from opentelemetry import metrics, trace
 from opentelemetry.sdk.metrics.export import ConsoleMetricExporter
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 
@@ -98,6 +99,8 @@ def configured_observability_console(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         otel, "_create_metric_exporter", lambda _obs: ConsoleMetricExporter()
     )
+    monkeypatch.setattr(trace, "set_tracer_provider", lambda _provider: None)
+    monkeypatch.setattr(metrics, "set_meter_provider", lambda _provider: None)
     otel.configure_observability(app_settings)
     try:
         yield app_settings

--- a/tests/unit/persistence/conftest.py
+++ b/tests/unit/persistence/conftest.py
@@ -4,22 +4,25 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterator
+from types import ModuleType
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _clear_llamaindex_modules() -> Iterator[None]:
-    """Ensure LlamaIndex modules are not cached before tests patch them."""
-    targets = [
-        "llama_index.core",
-        "llama_index.core.graph_stores",
-    ]
-    for name in targets:
-        sys.modules.pop(name, None)
+def llamaindex_module_registry() -> Iterator[pytest.MonkeyPatch]:
+    """Isolate LlamaIndex registry entries and restore exact package identity."""
+    registry = pytest.MonkeyPatch()
+    llama_index = sys.modules.get("llama_index")
+    core = sys.modules.get("llama_index.core")
+
+    if isinstance(core, ModuleType):
+        registry.delattr(core, "graph_stores", raising=False)
+    if isinstance(llama_index, ModuleType):
+        registry.delattr(llama_index, "core", raising=False)
+    registry.delitem(sys.modules, "llama_index.core.graph_stores", raising=False)
+    registry.delitem(sys.modules, "llama_index.core", raising=False)
     try:
-        yield
+        yield registry
     finally:
-        # Leave cleared to avoid leaking state across tests
-        for name in targets:
-            sys.modules.pop(name, None)
+        registry.undo()

--- a/tests/unit/persistence/test_snapshot_roundtrip.py
+++ b/tests/unit/persistence/test_snapshot_roundtrip.py
@@ -46,6 +46,7 @@ def _isolate_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 def test_snapshot_roundtrip_with_stubs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    llamaindex_module_registry: pytest.MonkeyPatch,
 ) -> None:
     from src.config.settings import settings
 
@@ -82,7 +83,7 @@ def test_snapshot_roundtrip_with_stubs(
     # sys.modules so subsequent imports within snapshot helpers resolve to these
     # stubs regardless of prior imports elsewhere in the suite.
     core_mod = ModuleType("llama_index.core")
-    monkeypatch.setitem(sys.modules, "llama_index.core", core_mod)
+    llamaindex_module_registry.setitem(sys.modules, "llama_index.core", core_mod)
 
     vector_store = SimpleNamespace(client=SimpleNamespace(close=lambda: None))
 
@@ -204,6 +205,7 @@ def test_property_graph_vector_retrieval_survives_snapshot_restart(
 def test_vector_activation_failure_closes_both_qdrant_clients(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    llamaindex_module_registry: pytest.MonkeyPatch,
 ) -> None:
     """A failed index wrapper construction releases both live-Qdrant clients."""
     mgr = SnapshotManager(tmp_path / "storage")
@@ -222,7 +224,7 @@ def test_vector_activation_failure_closes_both_qdrant_clients(
     final = mgr.finalize_snapshot(tmp).path
 
     core_mod = ModuleType("llama_index.core")
-    monkeypatch.setitem(sys.modules, "llama_index.core", core_mod)
+    llamaindex_module_registry.setitem(sys.modules, "llama_index.core", core_mod)
 
     class _VectorStoreIndex:
         @staticmethod

--- a/tests/unit/persistence/test_snapshot_service.py
+++ b/tests/unit/persistence/test_snapshot_service.py
@@ -82,11 +82,13 @@ def test_export_graphs_handles_missing_output_and_failures(
 
 
 def test_build_versions_falls_back_to_unknown_embed_model(
-    monkeypatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    llamaindex_module_registry: pytest.MonkeyPatch,
 ) -> None:
     li_core = ModuleType("llama_index.core")
     li_core.Settings = SimpleNamespace(embed_model=None)  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "llama_index.core", li_core)
+    llamaindex_module_registry.setitem(sys.modules, "llama_index.core", li_core)
     monkeypatch.setattr(svc, "get_version", lambda: "x")
     monkeypatch.setattr(svc.metadata, "version", lambda _dist: "0.14.21")
 

--- a/tests/unit/persistence/test_snapshot_verify_and_recover.py
+++ b/tests/unit/persistence/test_snapshot_verify_and_recover.py
@@ -391,6 +391,7 @@ def test_persist_graph_storage_context_uses_native_file_contract(
 
 def test_loaders_return_none_when_snapshot_missing(
     monkeypatch: pytest.MonkeyPatch,
+    llamaindex_module_registry: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         snap, "latest_snapshot_dir", lambda *_a, **_k: None, raising=True
@@ -402,13 +403,17 @@ def test_loaders_return_none_when_snapshot_missing(
     graph_mod = ModuleType("llama_index.core.graph_stores")
     core_mod.PropertyGraphIndex = object()  # type: ignore[attr-defined]
     graph_mod.SimplePropertyGraphStore = object()  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "llama_index.core", core_mod)
-    monkeypatch.setitem(sys.modules, "llama_index.core.graph_stores", graph_mod)
+    llamaindex_module_registry.setitem(sys.modules, "llama_index.core", core_mod)
+    llamaindex_module_registry.setitem(
+        sys.modules, "llama_index.core.graph_stores", graph_mod
+    )
     assert snap.load_property_graph_index(None) is None
 
 
 def test_loaders_return_none_when_payload_dirs_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    llamaindex_module_registry: pytest.MonkeyPatch,
 ) -> None:
     snapshot_dir = tmp_path / "snap"
     snapshot_dir.mkdir()
@@ -423,13 +428,17 @@ def test_loaders_return_none_when_payload_dirs_missing(
     graph_mod = ModuleType("llama_index.core.graph_stores")
     core_mod.PropertyGraphIndex = object()  # type: ignore[attr-defined]
     graph_mod.SimplePropertyGraphStore = object()  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "llama_index.core", core_mod)
-    monkeypatch.setitem(sys.modules, "llama_index.core.graph_stores", graph_mod)
+    llamaindex_module_registry.setitem(sys.modules, "llama_index.core", core_mod)
+    llamaindex_module_registry.setitem(
+        sys.modules, "llama_index.core.graph_stores", graph_mod
+    )
     assert snap.load_property_graph_index(None) is None
 
 
 def test_index_loaders_ignore_explicit_incomplete_snapshot(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    llamaindex_module_registry: pytest.MonkeyPatch,
 ) -> None:
     """Explicit index loads cannot bypass the complete-manifest gate."""
     snapshot_dir = tmp_path / "snap"
@@ -456,8 +465,10 @@ def test_index_loaders_ignore_explicit_incomplete_snapshot(
     core_mod.load_index_from_storage = object()  # type: ignore[attr-defined]
     core_mod.PropertyGraphIndex = object()  # type: ignore[attr-defined]
     graph_mod.SimplePropertyGraphStore = _UnexpectedGraphStore  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "llama_index.core", core_mod)
-    monkeypatch.setitem(sys.modules, "llama_index.core.graph_stores", graph_mod)
+    llamaindex_module_registry.setitem(sys.modules, "llama_index.core", core_mod)
+    llamaindex_module_registry.setitem(
+        sys.modules, "llama_index.core.graph_stores", graph_mod
+    )
 
     assert snap.load_vector_index(snapshot_dir) is None
     assert snap.load_property_graph_index(snapshot_dir) is None

--- a/tests/unit/telemetry/test_observability_config.py
+++ b/tests/unit/telemetry/test_observability_config.py
@@ -10,21 +10,27 @@ from src.telemetry import opentelemetry as otel
 
 def test_configure_observability_console(configured_observability_console) -> None:
     """Console exporters are registered when observability is enabled."""
-    tracer_provider = trace.get_tracer_provider()
-    meter_provider = metrics.get_meter_provider()
+    tracer_provider = otel.get_trace_provider()
+    meter_provider = otel.get_meter_provider()
     # Console fixtures install SDK providers; verify they are not no-op stubs.
+    assert tracer_provider is not None
+    assert meter_provider is not None
     assert tracer_provider.__class__.__name__ != "NoOpTracerProvider"
     assert meter_provider.__class__.__name__ != "NoOpMeterProvider"
 
 
 def test_configure_observability_disabled(monkeypatch) -> None:
     """When disabled, configuration leaves tracer/meter providers untouched."""
-    otel.shutdown_tracing()
-    otel.shutdown_metrics()
-    trace.set_tracer_provider(trace.NoOpTracerProvider())
-    metrics.set_meter_provider(metrics.NoOpMeterProvider())
-    start_tracer = trace.get_tracer_provider()
-    start_meter = metrics.get_meter_provider()
+    start_tracer = trace.NoOpTracerProvider()
+    start_meter = metrics.NoOpMeterProvider()
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: start_tracer)
+    monkeypatch.setattr(metrics, "get_meter_provider", lambda: start_meter)
+
+    def _unexpected_provider(_provider: object) -> None:
+        raise AssertionError("disabled configuration replaced a provider")
+
+    monkeypatch.setattr(trace, "set_tracer_provider", _unexpected_provider)
+    monkeypatch.setattr(metrics, "set_meter_provider", _unexpected_provider)
 
     original = settings.observability.model_copy()
     cfg = original.model_copy(update={"enabled": False})
@@ -33,7 +39,6 @@ def test_configure_observability_disabled(monkeypatch) -> None:
 
     assert trace.get_tracer_provider() is start_tracer
     assert metrics.get_meter_provider() is start_meter
-    settings.observability = original
 
 
 def test_observability_headers_formatted() -> None:


### PR DESCRIPTION
## Summary

- restore exact `llama_index.core` registry and parent-package identities after persistence tests, using one dedicated patcher for every module stub
- keep OpenTelemetry console/disabled tests inside DocMind-owned provider slots so they do not consume the API's process-global one-shot setters
- preserve production provider registration coverage in the dedicated setup tests; production code is unchanged

## Verification

- persistence-first reproducers: 10 passed, 24 passed, and 4 passed
- telemetry disabled → console order: 2 passed
- telemetry console → disabled order: 2 passed
- randomized seeds 165, 166, and 167: 1591 passed, 3 skipped for each seed
- ordinary unit/integration suite: 1591 passed, 3 skipped
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright --threads 4`
- `git diff --check`
- three independent adversarial reviews: ALLOW

Closes #166
