### PR TITLE
chore(deps): upgrade upload-artifact to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-python-3.12.13
           path: |


### PR DESCRIPTION
## Summary
- upgrade the sole remaining Node 20-era GitHub Action from `actions/upload-artifact@v4` to the current Node 24 `v7` major
- preserve the existing coverage artifact name, paths, archive behavior, and missing-file policy

## Verification
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- official v7 action metadata confirms the existing inputs and multi-path archive behavior remain supported
- three independent reviews found no actionable issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated coverage artifact upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->