### PR TITLE
chore(deps): upgrade release-please to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             exit 1
           fi
       - id: release
-        uses: googleapis/release-please-action@v4.4.0
+        uses: googleapis/release-please-action@v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           target-branch: main


### PR DESCRIPTION
## Summary
- upgrade `googleapis/release-please-action` from v4.4.0 to the current v5.0.0 release
- move the release workflow from the deprecated Node 20 action runtime to Node 24
- preserve the existing token, target branch, manifest/config inputs, outputs, permissions, and workflow-run gating

## Verification
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- official v4.4.0...v5.0.0 source comparison confirms the runtime is the only breaking contract change and the used inputs/outputs are unchanged
- three independent reviews found no actionable issues